### PR TITLE
fix: stop creating root.log on autoarray import

### DIFF
--- a/autoarray/config/logging.yaml
+++ b/autoarray/config/logging.yaml
@@ -7,15 +7,10 @@ handlers:
     level: INFO
     stream: ext://sys.stdout
     formatter: formatter
-  file:
-    class: logging.FileHandler
-    level: INFO
-    filename: root.log
-    formatter: formatter
 
 root:
   level: INFO
-  handlers: [ console, file ]
+  handlers: [ console ]
 
 formatters:
   formatter:

--- a/test_autoarray/config/logging.yaml
+++ b/test_autoarray/config/logging.yaml
@@ -7,15 +7,10 @@ handlers:
     level: INFO
     stream: ext://sys.stdout
     formatter: formatter
-  file:
-    class: logging.FileHandler
-    level: INFO
-    filename: root.log
-    formatter: formatter
 
 root:
   level: INFO
-  handlers: [ console, file ]
+  handlers: [ console ]
 
 formatters:
   formatter:


### PR DESCRIPTION
## Summary

Removes the `FileHandler` (with `filename: root.log`) from the packaged `autoarray/config/logging.yaml` and its test-config mirror. The handler was attached to the root logger unconditionally, so importing `autoarray` from a cwd whose own `config/logging.yaml` did not override it (e.g. a bare repo root) caused a `root.log` file to be dropped into that cwd. Console `StreamHandler` logging is unchanged.

Reproduction (before the fix): `cd <any dir without config/logging.yaml> && python -c "import autoarray"` → an empty `root.log` appears. After the fix the root logger has only a `StreamHandler` and no file is written.

## API Changes

None — internal configuration change only. No public Python symbols are affected.
See full details below.

## Test Plan

- [x] `pytest test_autoarray/ -x` → 732 passed
- [x] Repro check in a neutral cwd: `python -c "import autoarray; import logging; print([type(h).__name__ for h in logging.getLogger().handlers])"` reports `['StreamHandler']` only, and no `root.log` is written.
- [x] Regression check from `autofit_workspace/`: behaviour unchanged (workspace `logging.yaml` already won before; still wins now).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- (none — public API untouched)

### Added
- (none)

### Changed Behaviour
- Importing `autoarray` no longer attaches a `logging.FileHandler` writing to `root.log` in cwd. Users who relied on this implicit file log must now configure their own `FileHandler` in their workspace `config/logging.yaml`.

### Migration
- If a user wants file logging, add a `file` handler to their own `config/logging.yaml` and include it under `root.handlers`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)