### PR TITLE
Propagate xp through Grid2DIrregular.grid_2d_via_deflection_grid_from

### DIFF
--- a/autoarray/structures/grids/irregular_2d.py
+++ b/autoarray/structures/grids/irregular_2d.py
@@ -182,7 +182,7 @@ class Grid2DIrregular(AbstractNDArray):
         deflection_grid
             The grid of (y,x) coordinates which is subtracted from this grid.
         """
-        return Grid2DIrregular(values=self - deflection_grid)
+        return Grid2DIrregular(values=self - deflection_grid, xp=self._xp)
 
     def squared_distances_to_coordinate_from(
         self, coordinate: Tuple[float, float] = (0.0, 0.0)

--- a/test_autoarray/structures/grids/test_irregular_2d.py
+++ b/test_autoarray/structures/grids/test_irregular_2d.py
@@ -75,6 +75,25 @@ def test__grid_2d_via_deflection_grid_from():
     assert grid.in_list == [(0.0, 1.0), (1.0, 1.0)]
 
 
+def test__grid_2d_via_deflection_grid_from__propagates_xp():
+    # numpy-backed receiver -> numpy-backed result
+    grid_np = aa.Grid2DIrregular(values=[(1.0, 1.0), (2.0, 2.0)])
+    result_np = grid_np.grid_2d_via_deflection_grid_from(
+        deflection_grid=np.array([[1.0, 0.0], [1.0, 1.0]])
+    )
+    assert result_np._xp is np
+
+    # jax-backed receiver -> jax-backed result (so downstream .square calls use jnp)
+    jnp = pytest.importorskip("jax.numpy")
+    grid_jax = aa.Grid2DIrregular(
+        values=jnp.array([[1.0, 1.0], [2.0, 2.0]]), xp=jnp
+    )
+    result_jax = grid_jax.grid_2d_via_deflection_grid_from(
+        deflection_grid=jnp.array([[1.0, 0.0], [1.0, 1.0]])
+    )
+    assert result_jax._xp is jnp
+
+
 def test__furthest_distances_to_other_coordinates():
     grid = aa.Grid2DIrregular(values=[(0.0, 0.0), (0.0, 1.0)])
 


### PR DESCRIPTION
## Summary
`Grid2DIrregular.grid_2d_via_deflection_grid_from` previously constructed the result grid without propagating `xp=self._xp`, so a JAX-backed receiver produced a numpy-backed result whose values were still JAX tracers. Downstream `self._xp.square(...)` then called `np.square` on a tracer and raised `TracerArrayConversionError`, blocking JIT of point-source pipelines (see PyAutoLabs/PyAutoArray#286).

This one-line change passes `xp=self._xp` so the new grid inherits the receiver's backend, and adds a unit test covering both the np and jnp round-trips.

## API Changes
None — internal change only. Public signature unchanged; behaviour is only affected when the receiver's `_xp` is not numpy (in which case previously the result silently downgraded to numpy).
See full details below.

## Test Plan
- [x] Full PyAutoArray test suite passes (733 passed)
- [x] New `test__grid_2d_via_deflection_grid_from__propagates_xp` covers numpy + JAX round-trips
- [x] Downstream PyAutoLens point-source JIT pipeline traces end-to-end (was `TracerArrayConversionError` before, see stacked PR on PyAutoLens)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
None (unit test added, no public API additions).

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
- `Grid2DIrregular.grid_2d_via_deflection_grid_from` — the returned grid now has `_xp` matching the receiver's `_xp`. Previously always defaulted to numpy, silently downgrading JAX-backed callers.

### Migration
None — callers that were numpy-backed are unchanged. Callers that were JAX-backed and worked around the downgrade (e.g. by manually re-wrapping the result with `xp=jnp`) can drop the workaround.

</details>

Follows up: PyAutoLabs/PyAutoArray#286

🤖 Generated with [Claude Code](https://claude.com/claude-code)