### PR TITLE
jax: gated pytree registration for AbstractNDArray + generic helper

### DIFF
--- a/autoarray/abstract_ndarray.py
+++ b/autoarray/abstract_ndarray.py
@@ -62,6 +62,75 @@ def unwrap_array(func):
     return wrapper
 
 
+_pytree_registered_classes: set = set()
+
+
+def _register_as_pytree(cls):
+    """Register ``cls`` with ``jax.tree_util`` via the lazy autoconf wrapper.
+
+    Gated: only called when a subclass instance is constructed on the JAX path
+    (``xp is not np``). The registration is class-scoped via
+    ``_pytree_registered_classes`` so each subclass pays the cost at most once
+    regardless of how many instances are created. No-ops if JAX is not installed.
+    """
+    if cls in _pytree_registered_classes:
+        return
+    from autoconf.jax_wrapper import register_pytree_node
+
+    register_pytree_node(cls, cls.instance_flatten, cls.instance_unflatten)
+    _pytree_registered_classes.add(cls)
+
+
+def register_instance_pytree(cls, no_flatten=()):
+    """Register any class with ``jax.tree_util`` via ``__dict__`` flattening.
+
+    Generic counterpart to :func:`_register_as_pytree` for classes that are
+    *not* ``AbstractNDArray`` subclasses but still need to round-trip through
+    ``jax.jit`` (e.g. ``FitImaging``, ``Tracer``, ``Imaging``). Attributes are
+    partitioned using ``no_flatten``:
+
+    * Names **not** in ``no_flatten`` ride as pytree children — JAX traces them
+      and can substitute new values on unflatten (dynamic per fit).
+    * Names **in** ``no_flatten`` ride as ``aux_data`` — JAX treats them as
+      opaque Python objects, closing over the original reference across the
+      JIT boundary. Appropriate for per-analysis constants (dataset, settings,
+      cosmology, adapt images).
+
+    Reconstructs via ``cls.__new__`` + ``setattr`` (side-effect-free — no
+    ``__init__`` re-entry). Idempotent.
+    """
+    if cls in _pytree_registered_classes:
+        return
+    from autoconf.jax_wrapper import register_pytree_node
+
+    no_flatten_set = frozenset(no_flatten)
+
+    def flatten(instance):
+        dyn: list = []
+        static: list = []
+        for key, value in sorted(instance.__dict__.items()):
+            if key in no_flatten_set:
+                static.append((key, value))
+            else:
+                dyn.append((key, value))
+        dyn_keys = tuple(k for k, _ in dyn)
+        dyn_values = tuple(v for _, v in dyn)
+        static_items = tuple(static)
+        return dyn_values, (dyn_keys, static_items)
+
+    def unflatten(aux, children):
+        dyn_keys, static_items = aux
+        new = cls.__new__(cls)
+        for key, value in zip(dyn_keys, children):
+            setattr(new, key, value)
+        for key, value in static_items:
+            setattr(new, key, value)
+        return new
+
+    register_pytree_node(cls, flatten, unflatten)
+    _pytree_registered_classes.add(cls)
+
+
 class AbstractNDArray(ABC):
 
     __no_flatten__ = ()
@@ -75,6 +144,9 @@ class AbstractNDArray(ABC):
         self._array = array
 
         self.use_jax = xp is not np
+
+        if self.use_jax:
+            _register_as_pytree(type(self))
 
     @property
     def is_transformed(self) -> bool:

--- a/test_autoarray/test_jax_pytree.py
+++ b/test_autoarray/test_jax_pytree.py
@@ -1,0 +1,64 @@
+"""Tests for gated JAX pytree registration of ``AbstractNDArray`` subclasses.
+
+Follows the three-step pattern from ``autolens_workspace_test/scripts/hessian_jax.py``:
+1. NumPy path — confirm autoarray type with ``np.ndarray`` backing, no pytree registration.
+2. JAX path outside JIT — same autoarray type with ``jax.Array`` backing; pytree registered.
+3. JAX path through ``jax.jit`` — round-trip the instance and assert the output carries
+   a ``jax.Array`` leaf.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+
+from autoarray.abstract_ndarray import AbstractNDArray, _pytree_registered_classes
+
+
+class _LeafArray(AbstractNDArray):
+    """Minimal concrete ``AbstractNDArray`` with no nested autoarray children.
+
+    Isolates the pytree-registration machinery from the larger autoarray
+    hierarchy: a real ``Array2D`` also carries a ``Mask2D`` and other nested
+    ``AbstractNDArray`` children whose own registration is covered by
+    follow-up steps in the ``fit-imaging-pytree`` task.
+    """
+
+    @property
+    def native(self):
+        return self
+
+
+def test_numpy_path_does_not_register_pytree():
+    _pytree_registered_classes.discard(_LeafArray)
+
+    arr = _LeafArray(np.array([1.0, 2.0, 3.0]))
+
+    assert isinstance(arr._array, np.ndarray)
+    assert _LeafArray not in _pytree_registered_classes
+
+
+def test_jax_path_registers_pytree_once():
+    _pytree_registered_classes.discard(_LeafArray)
+
+    arr_jax = _LeafArray(jnp.array([1.0, 2.0, 3.0]), xp=jnp)
+
+    assert isinstance(arr_jax._array, jnp.ndarray)
+    assert _LeafArray in _pytree_registered_classes
+
+    # Second construction on the JAX path is a no-op; class stays registered.
+    _LeafArray(jnp.array([4.0, 5.0]), xp=jnp)
+    assert _LeafArray in _pytree_registered_classes
+
+
+def test_jax_jit_round_trip_returns_wrapper_with_jax_array():
+    arr_jax = _LeafArray(jnp.array([1.0, 2.0, 3.0]), xp=jnp)
+    assert _LeafArray in _pytree_registered_classes
+
+    result = jax.jit(lambda a: a)(arr_jax)
+
+    assert isinstance(result, _LeafArray)
+    assert isinstance(result._array, jnp.ndarray)
+    npt.assert_allclose(np.asarray(result._array), np.asarray(arr_jax._array))


### PR DESCRIPTION
## Summary
Reintroduces auto-registration of `AbstractNDArray` subclasses as JAX pytrees, gated so it only runs on the JAX path (`xp is not np`). Adds a generic `register_instance_pytree(cls, no_flatten=...)` helper for non-AbstractNDArray classes that higher-level libraries (PyAutoLens `FitImaging`, `Tracer`, `DatasetModel`) now opt into via their analysis layer. Together these make `jax.jit(analysis.fit_from)(instance)` return a real `FitImaging` with `jax.Array` leaves (see companion PR in PyAutoLens).

Issue: https://github.com/PyAutoLabs/PyAutoLens/issues/444

## API Changes
Two additions in `autoarray.abstract_ndarray`:

- `AbstractNDArray.__init__` now auto-registers its concrete subclass as a JAX pytree when `xp is not np`. Pure NumPy construction is unchanged.
- New public helper `register_instance_pytree(cls, no_flatten=...)` that registers arbitrary classes via `__dict__` flattening + `cls.__new__` reconstruction.

No removals, renames, or signature changes. Both additions are inert for pure NumPy callers.

See full details below.

## Test Plan
- [x] `pytest test_autoarray/` — 736 passed
- [x] New `test_autoarray/test_jax_pytree.py` — three-step pattern (NumPy / JAX-eager / `jax.jit` round-trip) on a minimal `AbstractNDArray` subclass
- [x] Downstream PoC in `autolens_workspace_test/scripts/jax_likelihood_functions/imaging/mge_pytree.py` — `jax.jit(analysis.fit_from)(instance).log_likelihood` matches NumPy path to ~1e-8 rel

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autoarray.abstract_ndarray.register_instance_pytree(cls, no_flatten=())` — register any class as a JAX pytree node via `__dict__` flattening. Names in `no_flatten` ride as `aux_data` (opaque Python objects closed over the JIT boundary); all other attributes ride as pytree children. Reconstruction uses `cls.__new__` + `setattr` (no `__init__` re-entry). Idempotent.
- Module-level `_pytree_registered_classes: set` sentinel in `autoarray.abstract_ndarray` (shared with the `AbstractNDArray` auto-registration path).

### Changed Behaviour
- `AbstractNDArray.__init__(array, xp=np)` — when `xp is not np` (i.e. caller is on the JAX path), registers `type(self)` as a JAX pytree node via `autoconf.jax_wrapper.register_pytree_node`. Registration is class-scoped so each subclass pays the cost at most once regardless of how many instances are constructed. No effect on the NumPy path.

### Migration
None. Pure NumPy callers see no change; JAX callers gain the ability to return autoarray wrappers from `jax.jit`-compiled functions.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)