### PR TITLE
Fix sign of poisson noise in preprocess.poisson_noise_via_data_eps_from

### DIFF
--- a/autoarray/dataset/preprocess.py
+++ b/autoarray/dataset/preprocess.py
@@ -472,10 +472,12 @@ def poisson_noise_via_data_eps_from(data_eps, exposure_time_map, seed=-1):
     """
     setup_random_seed(seed)
 
-    image_counts = np.multiply(data_eps.array, exposure_time_map.array)
-    return data_eps - np.divide(
-        np.random.poisson(image_counts, data_eps.shape), exposure_time_map.array
+    image_counts = data_eps.array * exposure_time_map.array
+    noisy_eps_array = (
+        np.random.poisson(image_counts, data_eps.shape) / exposure_time_map.array
     )
+
+    return data_eps.with_new_array(noisy_eps_array) - data_eps
 
 
 def data_eps_with_poisson_noise_added(data_eps, exposure_time_map, seed=-1):

--- a/test_autoarray/dataset/imaging/test_simulator.py
+++ b/test_autoarray/dataset/imaging/test_simulator.py
@@ -43,11 +43,13 @@ def test__via_image_from__psf_off__include_poisson_noise_in_noise_map(
     dataset = simulator.via_image_from(image=image)
 
     assert dataset.data.native == pytest.approx(
-        np.array([[1.05, 1.3, 1.25], [1.05, 2.1, 1.2], [1.05, 1.3, 1.15]]), 1e-2
+        np.array([[0.95, 0.7, 0.75], [0.95, 1.9, 0.8], [0.95, 0.7, 0.85]]), 1e-2
     )
 
     assert dataset.noise_map.native == pytest.approx(
-        np.array([[0.229, 0.255, 0.25], [0.229, 0.324, 0.245], [0.229, 0.255, 0.240]]),
+        np.array(
+            [[0.218, 0.187, 0.194], [0.218, 0.308, 0.2], [0.218, 0.187, 0.206]]
+        ),
         1e-2,
     )
 
@@ -85,10 +87,10 @@ def test__via_image_from__psf_off__background_sky_on(image_central_delta_3x3):
 
     assert (
         dataset.data.native
-        == np.array([[1.0, 5.0, 4.0], [1.0, 2.0, 1.0], [5.0, 2.0, 7.0]])
+        == np.array([[-1.0, -5.0, -4.0], [-1.0, 0.0, -1.0], [-5.0, -2.0, -7.0]])
     ).all()
 
-    assert dataset.noise_map.native[0, 0] == pytest.approx(4.12310, 1.0e-4)
+    assert dataset.noise_map.native[0, 0] == pytest.approx(3.87298, 1.0e-4)
 
 
 def test__via_image_from__psf_on__psf_blurs_image_with_edge_trimming(
@@ -143,7 +145,7 @@ def test__via_image_from__psf_on__disable_poisson_noise_in_data(
 
     assert dataset.noise_map.native == pytest.approx(
         np.array(
-            [[0.0, 0.22912, 0.0], [0.25495, 0.34278, 0.22912], [0.0, 0.229128, 0.0]]
+            [[0.0, 0.21794, 0.0], [0.18708, 0.28723, 0.21794], [0.0, 0.21794, 0.0]]
         ),
         1e-2,
     )
@@ -169,5 +171,5 @@ def test__via_image_from__psf_on__psf_and_noise_both_on(image_central_delta_3x3)
     dataset = simulator.via_image_from(image=image)
 
     assert dataset.data.native == pytest.approx(
-        np.array([[4.1, 6.65, 4.45], [6.15, 8.15, 6.5], [4.1, 6.7, 4.25]]), 1e-2
+        np.array([[3.9, 5.35, 3.55], [5.85, 7.85, 5.5], [3.9, 5.3, 3.75]]), 1e-2
     )

--- a/test_autoarray/dataset/test_preprocess.py
+++ b/test_autoarray/dataset/test_preprocess.py
@@ -612,7 +612,7 @@ def test__poisson_noise_from_data():
     )
 
     assert (
-        poisson_noise.native == np.array([[(10.0 - 9.0), 0], [0, (10.0 - 6.0)]])
+        poisson_noise.native == np.array([[(9.0 - 10.0), 0], [0, (6.0 - 10.0)]])
     ).all()
 
     data = aa.Array2D.full(fill_value=10.0, shape_native=(2, 2), pixel_scales=1.0)
@@ -623,7 +623,7 @@ def test__poisson_noise_from_data():
     )
 
     # Use known noise_map_1d map for given seed.
-    assert (poisson_noise.native == np.array([[1, 4], [3, 1]])).all()
+    assert (poisson_noise.native == np.array([[-1, -4], [-3, -1]])).all()
 
     data = aa.Array2D.no_mask(
         values=[[10000000.0, 0.0], [0.0, 10000000.0]], pixel_scales=1.0
@@ -634,7 +634,7 @@ def test__poisson_noise_from_data():
         data_eps=data, exposure_time_map=exposure_time_map, seed=1
     )
 
-    assert (poisson_noise.native == np.array([[743, 0], [0, 3783]])).all()
+    assert (poisson_noise.native == np.array([[-743, 0], [0, -3783]])).all()
 
 
 def test__data_with_poisson_noised_added():
@@ -654,7 +654,7 @@ def test__data_with_poisson_noised_added():
         data_eps=data, exposure_time_map=exposure_time_map, seed=1
     )
 
-    assert (data_with_poisson_noise.native == np.array([[11, 0], [0, 14]])).all()
+    assert (data_with_poisson_noise.native == np.array([[9, 0], [0, 6]])).all()
 
     data = aa.Array2D.full(fill_value=10.0, shape_native=(2, 2), pixel_scales=1.0)
 
@@ -663,7 +663,7 @@ def test__data_with_poisson_noised_added():
         data_eps=data, exposure_time_map=exposure_time_map, seed=1
     )
 
-    assert (data_with_poisson_noise.native == np.array([[11, 14], [13, 11]])).all()
+    assert (data_with_poisson_noise.native == np.array([[9, 6], [7, 9]])).all()
 
     data = aa.Array2D.no_mask(
         values=[[10000000.0, 0.0], [0.0, 10000000.0]], pixel_scales=1.0
@@ -676,7 +676,7 @@ def test__data_with_poisson_noised_added():
     )
 
     assert (
-        data_with_poisson_noise.native == np.array([[10000743, 0.0], [0.0, 10003783.0]])
+        data_with_poisson_noise.native == np.array([[9999257, 0.0], [0.0, 9996217.0]])
     ).all()
 
 


### PR DESCRIPTION
## Summary
`autoarray.preprocess.poisson_noise_via_data_eps_from` returned the wrong sign of the Poisson noise term. It computed `data_eps − noisy_eps` instead of `noisy_eps − data_eps`, so `data_eps_with_poisson_noise_added(...)` and `SimulatorImaging.via_image_from(..., add_poisson_noise_to_data=True)` produced `2·data − noisy_data` rather than `noisy_data`. Same mean and variance as a real Poisson sample but with mirrored skew (negative instead of positive), which biases inference on simulated low-count imaging.

Surfaced by `/health_check` on 2026-04-27.

## API Changes
Behaviour-only change to two existing functions (signatures unchanged):
- `preprocess.poisson_noise_via_data_eps_from` now returns the true Poisson noise term (`noisy − data`) instead of its negation.
- `preprocess.data_eps_with_poisson_noise_added` and `SimulatorImaging.via_image_from(..., add_poisson_noise_to_data=True)` therefore produce data with the correct Poisson distribution and skew — same seed, different numerical values.

Implementation also routes the result through `data_eps.with_new_array(...)` so the return type is an `Array2D` (not a raw `np.ndarray`), which the previous in-progress edit had inadvertently changed.

Any code asserting against specific seeded outputs of these functions will need expected values regenerated. Anything using the result as a noisy realisation (modelling, inference) will now see correctly-skewed samples — typically more accurate, not less.

See full details below.

## Test Plan
- [x] `pytest test_autoarray/dataset/test_preprocess.py test_autoarray/dataset/imaging/test_simulator.py` — 34/34 green
- [x] Full `pytest test_autoarray/` — 748/748 green
- [ ] Workspace smoke tests across PyAutoFit/Galaxy/Lens workspaces (run on PR via `/smoke_test`)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autoarray.preprocess.poisson_noise_via_data_eps_from(data_eps, exposure_time_map, seed=-1)` — sign of returned noise corrected. Was `data_eps − noisy_eps`, now `noisy_eps − data_eps`. Result is now correctly typed `Array2D` (matches input).
- `autoarray.preprocess.data_eps_with_poisson_noise_added(...)` — downstream consequence. Result is now a true Poisson realisation of `data_eps` rather than its mirror image around the mean.
- `autoarray.SimulatorImaging.via_image_from(...)` — when `add_poisson_noise_to_data=True`, simulated data and (when `include_poisson_noise_in_noise_map=True`) the noise map both shift to correct Poisson statistics.

### Migration
- No code changes required. If you have tests that pin specific values for these functions under a fixed seed, re-derive expected values against the fixed code.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)