### PR TITLE
Fix subplot_of_mapper crash on interferometer data_subtracted

### DIFF
--- a/autoarray/inversion/plot/inversion_plots.py
+++ b/autoarray/inversion/plot/inversion_plots.py
@@ -60,8 +60,13 @@ def subplot_of_mapper(
 
     # panel 0: data subtracted
     try:
+        array = inversion.data_subtracted_dict[mapper]
+        from autoarray.structures.visibilities import Visibilities
+
+        if isinstance(array, Visibilities):
+            array = inversion.transformer.image_from(visibilities=array)
         plot_array(
-            inversion.data_subtracted_dict[mapper],
+            array,
             ax=axes[0],
             title=_pf("Data Subtracted"),
             colormap=colormap,
@@ -286,8 +291,13 @@ def subplot_mappings(
 
     # panel 0: data subtracted
     try:
+        array = inversion.data_subtracted_dict[mapper]
+        from autoarray.structures.visibilities import Visibilities
+
+        if isinstance(array, Visibilities):
+            array = inversion.transformer.image_from(visibilities=array)
         plot_array(
-            inversion.data_subtracted_dict[mapper],
+            array,
             ax=axes[0],
             title="Data Subtracted",
             colormap=colormap,


### PR DESCRIPTION
## Summary

`subplot_of_mapper` and `subplot_mappings` panel 0 crashed on every interferometer pixelization fit with `ValueError: not enough values to unpack (expected 2, got 1)`. The panels passed `inversion.data_subtracted_dict[mapper]` straight to `plot_array`, which expects a 2D array — but for interferometer fits the entry is `Visibilities` (1D complex).

This mirrors the existing `Visibilities` handling already used by panels 1-3: when the data is `Visibilities`, transform to a 2D dirty image via `inversion.transformer.image_from(...)` — the same call `FitInterferometer.dirty_residual_map` uses. The imaging path is untouched.

Fixes the 3 release-prep failures grouped as Cluster G + Cluster H in `PyAutoBuild/test_results/runs/2026-04-29T14-48-47Z/triage.md`:
- `autogalaxy_workspace/scripts/interferometer/features/pixelization/fit.py`
- `autolens_workspace/scripts/interferometer/features/pixelization/fit.py`
- `autolens_workspace_test/scripts/interferometer/visualization.py`

## API Changes

None — internal change to a plot helper. `subplot_of_mapper` / `subplot_mappings` signatures unchanged; behaviour for imaging fits is byte-identical. Interferometer fits previously crashed in panel 0; they now render a dirty data-subtracted image.

See full details below.

## Test Plan
- [x] `python scripts/interferometer/features/pixelization/fit.py` (autogalaxy_workspace) — passes
- [x] `python scripts/interferometer/features/pixelization/fit.py` (autolens_workspace) — passes
- [x] `python scripts/interferometer/visualization.py` (autolens_workspace_test) — passes; rectangular + delaunay inversion subplots produced
- [x] `python scripts/imaging/features/pixelization/fit.py` (autolens_workspace) — sanity, imaging path unchanged
- [x] `python -m pytest test_autoarray/inversion/` — 162 passed

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Changed Behaviour
- \`autoarray.inversion.plot.inversion_plots.subplot_of_mapper\` panel 0 — for interferometer inversions, now renders a dirty image of the residual visibilities (via \`inversion.transformer.image_from\`) instead of crashing. Imaging panel 0 unchanged.
- \`autoarray.inversion.plot.inversion_plots.subplot_mappings\` panel 0 — same change.

### Migration
- None required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)