### PR TITLE
refactor: replace os.path with pathlib

### DIFF
--- a/autoarray/plot/output.py
+++ b/autoarray/plot/output.py
@@ -1,6 +1,6 @@
 import logging
-from os import path
 import os
+from pathlib import Path
 from typing import Union, List, Optional
 
 from autoarray.structures.abstract_structure import Structure
@@ -100,7 +100,7 @@ class Output:
             return None
 
         if self.format_folder:
-            output_path = path.join(self.path, format)
+            output_path = str(Path(self.path) / format)
         else:
             output_path = self.path
 
@@ -156,7 +156,7 @@ class Output:
 
         try:
             plt.savefig(
-                path.join(output_path, f"{filename}.{format}"),
+                str(Path(output_path) / f"{filename}.{format}"),
                 bbox_inches=self.bbox_inches,
                 pad_inches=0.1,
             )
@@ -257,9 +257,9 @@ class Output:
 
         import sys
 
-        script_name = path.split(sys.argv[0])[-1].replace(".py", "")
+        script_name = Path(sys.argv[0]).name.replace(".py", "")
 
-        output_path = path.join(os.getcwd(), "output_mode", script_name)
+        output_path = str(Path(os.getcwd()) / "output_mode" / script_name)
         os.makedirs(output_path, exist_ok=True)
 
         self.savefig(f"{COUNT}_{filename}", output_path, "png")

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -4,6 +4,7 @@ Shared utilities for the direct-matplotlib plot functions.
 
 import logging
 import os
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -310,8 +311,8 @@ def _output_mode_save(fig, filename):
 
     import sys
 
-    script_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
-    output_path = os.path.join(os.getcwd(), "output_mode", script_name)
+    script_name = Path(sys.argv[0]).stem
+    output_path = str(Path(os.getcwd()) / "output_mode" / script_name)
     os.makedirs(output_path, exist_ok=True)
 
     count = getattr(_output_mode_save, "_count", -1) + 1
@@ -319,7 +320,7 @@ def _output_mode_save(fig, filename):
 
     try:
         fig.savefig(
-            os.path.join(output_path, f"{count}_{filename}.png"),
+            str(Path(output_path) / f"{count}_{filename}.png"),
             dpi=150,
             bbox_inches="tight",
             pad_inches=0.1,
@@ -371,7 +372,7 @@ def subplot_save(fig, output_path, output_filename, output_format=None):
         os.makedirs(output_path, exist_ok=True)
         try:
             fig.savefig(
-                os.path.join(output_path, f"{output_filename}.{output_format}"),
+                str(Path(output_path) / f"{output_filename}.{output_format}"),
                 bbox_inches="tight",
                 pad_inches=0.1,
             )
@@ -552,7 +553,7 @@ def save_figure(
                 continue
             try:
                 fig.savefig(
-                    os.path.join(path, f"{filename}.{fmt}"),
+                    str(Path(path) / f"{filename}.{fmt}"),
                     dpi=dpi,
                     bbox_inches="tight",
                     pad_inches=0.1,

--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from pathlib import Path
 
 
 def should_simulate(dataset_path):
@@ -18,7 +19,7 @@ def should_simulate(dataset_path):
             subprocess.run([sys.executable, "scripts/.../simulator.py"], check=True)
     """
     if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
-        if os.path.exists(dataset_path):
+        if Path(dataset_path).exists():
             shutil.rmtree(dataset_path)
 
-    return not os.path.exists(dataset_path)
+    return not Path(dataset_path).exists()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,11 +10,11 @@ import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# documentation root, use Path(...).resolve() to make it absolute, like shown here.
 #
-# import os
 # import sys
-# sys.path.insert(0, os.path.abspath('.'))
+# from pathlib import Path
+# sys.path.insert(0, str(Path(".").resolve()))
 
 # -- Project information -----------------------------------------------------
 

--- a/test_autoarray/conftest.py
+++ b/test_autoarray/conftest.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 import pytest
 from matplotlib import pyplot
 
@@ -12,7 +12,7 @@ class PlotPatch:
         self.paths = []
 
     def __call__(self, path, *args, **kwargs):
-        self.paths.append(path)
+        self.paths.append(str(path))
 
 
 @pytest.fixture(name="plot_patch")
@@ -25,7 +25,7 @@ def make_plot_patch(monkeypatch):
     return plot_patch
 
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -34,7 +34,7 @@ def remove_logs():
     for d, _, files in os.walk(directory):
         for file in files:
             if file.endswith(".log"):
-                os.remove(path.join(d, file))
+                os.remove(Path(d) / file)
 
 
 @pytest.fixture(autouse=True)
@@ -42,8 +42,8 @@ def set_config_path(request):
     # if dirname(realpath(__file__)) in str(request.module):
 
     conf.instance.push(
-        new_path=path.join(directory, "config"),
-        output_path=path.join(directory, "output"),
+        new_path=str(directory / "config"),
+        output_path=str(directory / "output"),
     )
 
 

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -1,6 +1,5 @@
 import copy
 import os
-from os import path
 
 import numpy as np
 import pytest
@@ -9,23 +8,16 @@ import shutil
 import autoarray as aa
 
 from autoarray import exc
+from pathlib import Path
 
-test_data_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))),
-    "files",
-)
+test_data_path = Path(Path(__file__).resolve().parent) / "files"
 
 
 @pytest.fixture(name="test_data_path")
 def make_test_data_path():
-    test_data_path = path.join(
-        "{}".format(os.path.dirname(os.path.realpath(__file__))),
-        "files",
-        "array",
-        "output_test",
-    )
+    test_data_path = Path(__file__).resolve().parent / "files" / "array" / "output_test"
 
-    if os.path.exists(test_data_path):
+    if test_data_path.exists():
         shutil.rmtree(test_data_path)
 
     os.makedirs(test_data_path)
@@ -132,9 +124,9 @@ def test__no_noise_map__raises_exception():
 def test__from_fits__separate_fits_files__loads_data_psf_noise_map_correctly():
     dataset = aa.Imaging.from_fits(
         pixel_scales=0.1,
-        data_path=path.join(test_data_path, "3x3_ones.fits"),
-        psf_path=path.join(test_data_path, "3x3_twos.fits"),
-        noise_map_path=path.join(test_data_path, "3x3_threes.fits"),
+        data_path=Path(test_data_path) / "3x3_ones.fits",
+        psf_path=Path(test_data_path) / "3x3_twos.fits",
+        noise_map_path=Path(test_data_path) / "3x3_threes.fits",
     )
 
     assert (dataset.data.native == np.ones((3, 3))).all()
@@ -151,11 +143,11 @@ def test__from_fits__separate_fits_files__loads_data_psf_noise_map_correctly():
 def test__from_fits__all_data_in_one_fits_file_multiple_hdus__loads_data_psf_noise_map_correctly():
     dataset = aa.Imaging.from_fits(
         pixel_scales=0.1,
-        data_path=path.join(test_data_path, "3x3_multiple_hdu.fits"),
+        data_path=Path(test_data_path) / "3x3_multiple_hdu.fits",
         data_hdu=0,
-        psf_path=path.join(test_data_path, "3x3_multiple_hdu.fits"),
+        psf_path=Path(test_data_path) / "3x3_multiple_hdu.fits",
         psf_hdu=1,
-        noise_map_path=path.join(test_data_path, "3x3_multiple_hdu.fits"),
+        noise_map_path=Path(test_data_path) / "3x3_multiple_hdu.fits",
         noise_map_hdu=2,
     )
 
@@ -178,17 +170,17 @@ def test__output_to_fits__round_trips_data_psf_noise_map_correctly(
 
     fits_imaging(
         dataset=imaging_7x7,
-        data_path=path.join(test_data_path, "data.fits"),
-        psf_path=path.join(test_data_path, "psf.fits"),
-        noise_map_path=path.join(test_data_path, "noise_map.fits"),
+        data_path=Path(test_data_path) / "data.fits",
+        psf_path=Path(test_data_path) / "psf.fits",
+        noise_map_path=Path(test_data_path) / "noise_map.fits",
         overwrite=True,
     )
 
     dataset = aa.Imaging.from_fits(
         pixel_scales=0.1,
-        data_path=path.join(test_data_path, "data.fits"),
-        psf_path=path.join(test_data_path, "psf.fits"),
-        noise_map_path=path.join(test_data_path, "noise_map.fits"),
+        data_path=Path(test_data_path) / "data.fits",
+        psf_path=Path(test_data_path) / "psf.fits",
+        noise_map_path=Path(test_data_path) / "noise_map.fits",
     )
 
     assert (dataset.data.native == np.ones((7, 7))).all()

--- a/test_autoarray/dataset/interferometer/test_dataset.py
+++ b/test_autoarray/dataset/interferometer/test_dataset.py
@@ -1,17 +1,14 @@
 import numpy as np
 import os
-from os import path
 import shutil
 
 import autoarray as aa
 import pytest
 
 from autoarray.operators import transformer
+from pathlib import Path
 
-test_data_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))),
-    "files",
-)
+test_data_path = Path(Path(__file__).resolve().parent) / "files"
 
 
 def test__dirty_image__shape_native_matches_real_space_mask(
@@ -70,11 +67,11 @@ def test__dirty_signal_to_noise_map__shape_native_matches_real_space_mask(
 def test__from_fits__all_files_in_one_fits__load_using_different_hdus(mask_2d_7x7):
     dataset = aa.Interferometer.from_fits(
         real_space_mask=mask_2d_7x7,
-        data_path=path.join(test_data_path, "3x2_multiple_hdu.fits"),
+        data_path=Path(test_data_path) / "3x2_multiple_hdu.fits",
         visibilities_hdu=0,
-        noise_map_path=path.join(test_data_path, "3x2_multiple_hdu.fits"),
+        noise_map_path=Path(test_data_path) / "3x2_multiple_hdu.fits",
         noise_map_hdu=1,
-        uv_wavelengths_path=path.join(test_data_path, "3x2_multiple_hdu.fits"),
+        uv_wavelengths_path=Path(test_data_path) / "3x2_multiple_hdu.fits",
         uv_wavelengths_hdu=2,
     )
 
@@ -85,26 +82,18 @@ def test__from_fits__all_files_in_one_fits__load_using_different_hdus(mask_2d_7x
 
 
 def test__output_all_arrays(mask_2d_7x7):
-    test_data_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-    )
+    test_data_path = Path(Path(__file__).resolve().parent) / "files"
 
     dataset = aa.Interferometer.from_fits(
         real_space_mask=mask_2d_7x7,
-        data_path=path.join(test_data_path, "3x2_ones_twos.fits"),
-        noise_map_path=path.join(test_data_path, "3x2_threes_fours.fits"),
-        uv_wavelengths_path=path.join(test_data_path, "3x2_fives_sixes.fits"),
+        data_path=Path(test_data_path) / "3x2_ones_twos.fits",
+        noise_map_path=Path(test_data_path) / "3x2_threes_fours.fits",
+        uv_wavelengths_path=Path(test_data_path) / "3x2_fives_sixes.fits",
     )
 
-    test_data_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "array",
-        "output_test",
-    )
+    test_data_path = Path(Path(__file__).resolve().parent) / "files" / "array" / "output_test"
 
-    if path.exists(test_data_path):
+    if Path(test_data_path).exists():
         shutil.rmtree(test_data_path)
 
     os.makedirs(test_data_path)
@@ -113,17 +102,17 @@ def test__output_all_arrays(mask_2d_7x7):
 
     fits_interferometer(
         dataset=dataset,
-        data_path=path.join(test_data_path, "data.fits"),
-        noise_map_path=path.join(test_data_path, "noise_map.fits"),
-        uv_wavelengths_path=path.join(test_data_path, "uv_wavelengths.fits"),
+        data_path=Path(test_data_path) / "data.fits",
+        noise_map_path=Path(test_data_path) / "noise_map.fits",
+        uv_wavelengths_path=Path(test_data_path) / "uv_wavelengths.fits",
         overwrite=True,
     )
 
     dataset = aa.Interferometer.from_fits(
         real_space_mask=mask_2d_7x7,
-        data_path=path.join(test_data_path, "data.fits"),
-        noise_map_path=path.join(test_data_path, "noise_map.fits"),
-        uv_wavelengths_path=path.join(test_data_path, "uv_wavelengths.fits"),
+        data_path=Path(test_data_path) / "data.fits",
+        noise_map_path=Path(test_data_path) / "noise_map.fits",
+        uv_wavelengths_path=Path(test_data_path) / "uv_wavelengths.fits",
     )
 
     assert (dataset.data == np.array([1.0 + 2.0j, 1.0 + 2.0j, 1.0 + 2.0j])).all()

--- a/test_autoarray/dataset/plot/test_imaging_plotters.py
+++ b/test_autoarray/dataset/plot/test_imaging_plotters.py
@@ -1,18 +1,16 @@
-from os import path
 import pytest
 import autoarray as aa
 import autoarray.plot as aplt
 from autoarray.dataset.plot.imaging_plots import subplot_imaging_dataset
+from pathlib import Path
 
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "imaging"
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "imaging"
 
 
 def test__individual_attributes_are_output(
@@ -25,7 +23,7 @@ def test__individual_attributes_are_output(
         output_filename="data",
         output_format="png",
     )
-    assert path.join(plot_path, "data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=imaging_7x7.noise_map,
@@ -33,7 +31,7 @@ def test__individual_attributes_are_output(
         output_filename="noise_map",
         output_format="png",
     )
-    assert path.join(plot_path, "noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "noise_map.png") in plot_patch.paths
 
     if imaging_7x7.psf is not None:
         aplt.plot_array_2d(
@@ -42,7 +40,7 @@ def test__individual_attributes_are_output(
             output_filename="psf",
             output_format="png",
         )
-        assert path.join(plot_path, "psf.png") in plot_patch.paths
+        assert str(Path(plot_path) / "psf.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=imaging_7x7.signal_to_noise_map,
@@ -50,7 +48,7 @@ def test__individual_attributes_are_output(
         output_filename="signal_to_noise_map",
         output_format="png",
     )
-    assert path.join(plot_path, "signal_to_noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "signal_to_noise_map.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=imaging_7x7.grids.over_sample_size_lp,
@@ -58,7 +56,7 @@ def test__individual_attributes_are_output(
         output_filename="over_sample_size_lp",
         output_format="png",
     )
-    assert path.join(plot_path, "over_sample_size_lp.png") in plot_patch.paths
+    assert str(Path(plot_path) / "over_sample_size_lp.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=imaging_7x7.grids.over_sample_size_pixelization,
@@ -66,7 +64,7 @@ def test__individual_attributes_are_output(
         output_filename="over_sample_size_pixelization",
         output_format="png",
     )
-    assert path.join(plot_path, "over_sample_size_pixelization.png") in plot_patch.paths
+    assert str(Path(plot_path) / "over_sample_size_pixelization.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -76,8 +74,8 @@ def test__individual_attributes_are_output(
         output_filename="data",
         output_format="png",
     )
-    assert path.join(plot_path, "data.png") in plot_patch.paths
-    assert not path.join(plot_path, "noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
+    assert not str(Path(plot_path) / "noise_map.png") in plot_patch.paths
 
 
 def test__subplot_is_output(
@@ -89,7 +87,7 @@ def test__subplot_is_output(
         output_format="png",
     )
 
-    assert path.join(plot_path, "dataset.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dataset.png") in plot_patch.paths
 
 
 def test__output_as_fits__correct_output_format(
@@ -103,7 +101,7 @@ def test__output_as_fits__correct_output_format(
     )
 
     image_from_plot = aa.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "data.fits"), hdu=0
+        file_path=Path(plot_path) / "data.fits", hdu=0
     )
 
     assert image_from_plot.shape == (7, 7)

--- a/test_autoarray/dataset/plot/test_interferometer_plotters.py
+++ b/test_autoarray/dataset/plot/test_interferometer_plotters.py
@@ -1,23 +1,18 @@
-from os import path
 
 import pytest
+from pathlib import Path
 import autoarray.plot as aplt
 from autoarray.dataset.plot.interferometer_plots import (
     subplot_interferometer_dataset,
     subplot_interferometer_dirty_images,
 )
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "interferometer",
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "interferometer"
 
 
 def test__individual_attributes_are_output(interferometer_7, plot_path, plot_patch):
@@ -27,7 +22,7 @@ def test__individual_attributes_are_output(interferometer_7, plot_path, plot_pat
         output_filename="data",
         output_format="png",
     )
-    assert path.join(plot_path, "data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=interferometer_7.dirty_image,
@@ -35,7 +30,7 @@ def test__individual_attributes_are_output(interferometer_7, plot_path, plot_pat
         output_filename="dirty_image",
         output_format="png",
     )
-    assert path.join(plot_path, "dirty_image.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dirty_image.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=interferometer_7.dirty_noise_map,
@@ -43,7 +38,7 @@ def test__individual_attributes_are_output(interferometer_7, plot_path, plot_pat
         output_filename="dirty_noise_map",
         output_format="png",
     )
-    assert path.join(plot_path, "dirty_noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dirty_noise_map.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=interferometer_7.dirty_signal_to_noise_map,
@@ -51,7 +46,7 @@ def test__individual_attributes_are_output(interferometer_7, plot_path, plot_pat
         output_filename="dirty_signal_to_noise_map",
         output_format="png",
     )
-    assert path.join(plot_path, "dirty_signal_to_noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dirty_signal_to_noise_map.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -61,8 +56,8 @@ def test__individual_attributes_are_output(interferometer_7, plot_path, plot_pat
         output_filename="data",
         output_format="png",
     )
-    assert path.join(plot_path, "data.png") in plot_patch.paths
-    assert not path.join(plot_path, "dirty_image.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
+    assert not str(Path(plot_path) / "dirty_image.png") in plot_patch.paths
 
 
 def test__subplots_are_output(interferometer_7, plot_path, plot_patch):
@@ -72,7 +67,7 @@ def test__subplots_are_output(interferometer_7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "dataset.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dataset.png") in plot_patch.paths
 
     subplot_interferometer_dirty_images(
         dataset=interferometer_7,
@@ -80,4 +75,4 @@ def test__subplots_are_output(interferometer_7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "dirty_images.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dirty_images.png") in plot_patch.paths

--- a/test_autoarray/dataset/test_preprocess.py
+++ b/test_autoarray/dataset/test_preprocess.py
@@ -1,15 +1,13 @@
 import os
-from os import path
 
 import numpy as np
 import pytest
 import shutil
 
 import autoarray as aa
+from pathlib import Path
 
-test_data_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))), "files", "imaging"
-)
+test_data_path = Path(Path(__file__).resolve().parent) / "files" / "imaging"
 
 
 def test__array_with_new_shape():

--- a/test_autoarray/fit/plot/test_fit_imaging_plotters.py
+++ b/test_autoarray/fit/plot/test_fit_imaging_plotters.py
@@ -1,19 +1,14 @@
 import autoarray as aa
 import autoarray.plot as aplt
 import pytest
-from os import path
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "fit_dataset",
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "fit_dataset"
 
 
 def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
@@ -23,7 +18,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="data",
         output_format="png",
     )
-    assert path.join(plot_path, "data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_imaging_7x7.noise_map,
@@ -31,7 +26,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="noise_map",
         output_format="png",
     )
-    assert path.join(plot_path, "noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "noise_map.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_imaging_7x7.signal_to_noise_map,
@@ -39,7 +34,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="signal_to_noise_map",
         output_format="png",
     )
-    assert path.join(plot_path, "signal_to_noise_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "signal_to_noise_map.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_imaging_7x7.model_data,
@@ -47,7 +42,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="model_image",
         output_format="png",
     )
-    assert path.join(plot_path, "model_image.png") in plot_patch.paths
+    assert str(Path(plot_path) / "model_image.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_imaging_7x7.residual_map,
@@ -55,7 +50,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="residual_map",
         output_format="png",
     )
-    assert path.join(plot_path, "residual_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "residual_map.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_imaging_7x7.normalized_residual_map,
@@ -63,7 +58,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="normalized_residual_map",
         output_format="png",
     )
-    assert path.join(plot_path, "normalized_residual_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "normalized_residual_map.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_imaging_7x7.chi_squared_map,
@@ -71,7 +66,7 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_filename="chi_squared_map",
         output_format="png",
     )
-    assert path.join(plot_path, "chi_squared_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "chi_squared_map.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -94,13 +89,13 @@ def test__fit_quantities_are_output(fit_imaging_7x7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "data.png") in plot_patch.paths
-    assert path.join(plot_path, "noise_map.png") not in plot_patch.paths
-    assert path.join(plot_path, "signal_to_noise_map.png") not in plot_patch.paths
-    assert path.join(plot_path, "model_image.png") in plot_patch.paths
-    assert path.join(plot_path, "residual_map.png") not in plot_patch.paths
-    assert path.join(plot_path, "normalized_residual_map.png") not in plot_patch.paths
-    assert path.join(plot_path, "chi_squared_map.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "noise_map.png") not in plot_patch.paths
+    assert str(Path(plot_path) / "signal_to_noise_map.png") not in plot_patch.paths
+    assert str(Path(plot_path) / "model_image.png") in plot_patch.paths
+    assert str(Path(plot_path) / "residual_map.png") not in plot_patch.paths
+    assert str(Path(plot_path) / "normalized_residual_map.png") not in plot_patch.paths
+    assert str(Path(plot_path) / "chi_squared_map.png") in plot_patch.paths
 
 
 def test__fit_sub_plot(fit_imaging_7x7, plot_path, plot_patch):
@@ -110,7 +105,7 @@ def test__fit_sub_plot(fit_imaging_7x7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(Path(plot_path) / "fit.png") in plot_patch.paths
 
 
 def test__output_as_fits__correct_output_format(
@@ -124,7 +119,7 @@ def test__output_as_fits__correct_output_format(
     )
 
     image_from_plot = aa.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "data.fits"), hdu=0
+        file_path=Path(plot_path) / "data.fits", hdu=0
     )
 
     assert image_from_plot.shape == (5, 5)

--- a/test_autoarray/fit/plot/test_fit_interferometer_plotters.py
+++ b/test_autoarray/fit/plot/test_fit_interferometer_plotters.py
@@ -1,20 +1,15 @@
 import autoarray.plot as aplt
 import numpy as np
 import pytest
+from pathlib import Path
 
-from os import path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "fit_dataset",
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "fit_dataset"
 
 
 def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch):
@@ -26,7 +21,7 @@ def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch)
         output_filename="data",
         output_format="png",
     )
-    assert path.join(plot_path, "data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
 
     aplt.plot_yx_1d(
         y=np.real(fit_interferometer_7.residual_map),
@@ -36,10 +31,7 @@ def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch)
         output_format="png",
         plot_axis_type="scatter",
     )
-    assert (
-        path.join(plot_path, "real_residual_map_vs_uv_distances.png")
-        in plot_patch.paths
-    )
+    assert str(Path(plot_path) / "real_residual_map_vs_uv_distances.png") in plot_patch.paths
 
     aplt.plot_yx_1d(
         y=np.real(fit_interferometer_7.chi_squared_map),
@@ -49,10 +41,7 @@ def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch)
         output_format="png",
         plot_axis_type="scatter",
     )
-    assert (
-        path.join(plot_path, "real_chi_squared_map_vs_uv_distances.png")
-        in plot_patch.paths
-    )
+    assert str(Path(plot_path) / "real_chi_squared_map_vs_uv_distances.png") in plot_patch.paths
 
     aplt.plot_yx_1d(
         y=np.imag(fit_interferometer_7.chi_squared_map),
@@ -62,10 +51,7 @@ def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch)
         output_format="png",
         plot_axis_type="scatter",
     )
-    assert (
-        path.join(plot_path, "imag_chi_squared_map_vs_uv_distances.png")
-        in plot_patch.paths
-    )
+    assert str(Path(plot_path) / "imag_chi_squared_map_vs_uv_distances.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=fit_interferometer_7.dirty_image,
@@ -73,7 +59,7 @@ def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch)
         output_filename="dirty_image",
         output_format="png",
     )
-    assert path.join(plot_path, "dirty_image.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dirty_image.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -100,19 +86,10 @@ def test__fit_quantities_are_output(fit_interferometer_7, plot_path, plot_patch)
         plot_axis_type="scatter",
     )
 
-    assert path.join(plot_path, "data.png") in plot_patch.paths
-    assert (
-        path.join(plot_path, "real_chi_squared_map_vs_uv_distances.png")
-        in plot_patch.paths
-    )
-    assert (
-        path.join(plot_path, "imag_chi_squared_map_vs_uv_distances.png")
-        in plot_patch.paths
-    )
-    assert (
-        path.join(plot_path, "real_residual_map_vs_uv_distances.png")
-        not in plot_patch.paths
-    )
+    assert str(Path(plot_path) / "data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "real_chi_squared_map_vs_uv_distances.png") in plot_patch.paths
+    assert str(Path(plot_path) / "imag_chi_squared_map_vs_uv_distances.png") in plot_patch.paths
+    assert str(Path(plot_path) / "real_residual_map_vs_uv_distances.png") not in plot_patch.paths
 
 
 def test__fit_sub_plots(fit_interferometer_7, plot_path, plot_patch):
@@ -122,7 +99,7 @@ def test__fit_sub_plots(fit_interferometer_7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(Path(plot_path) / "fit.png") in plot_patch.paths
 
     aplt.subplot_fit_interferometer_dirty_images(
         fit=fit_interferometer_7,
@@ -130,4 +107,4 @@ def test__fit_sub_plots(fit_interferometer_7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "fit_dirty_images.png") in plot_patch.paths
+    assert str(Path(plot_path) / "fit_dirty_images.png") in plot_patch.paths

--- a/test_autoarray/inversion/inversion/imaging/test_imaging.py
+++ b/test_autoarray/inversion/inversion/imaging/test_imaging.py
@@ -10,10 +10,10 @@ from autoarray.inversion.inversion.imaging.sparse import (
 from autoarray import exc
 
 import numpy as np
-from os import path
 import pytest
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__operated_mapping_matrix_property(psf_3x3, rectangular_mapper_7x7_3x3):

--- a/test_autoarray/inversion/inversion/interferometer/test_interferometer.py
+++ b/test_autoarray/inversion/inversion/interferometer/test_interferometer.py
@@ -1,10 +1,10 @@
 import autoarray as aa
 
 import numpy as np
-from os import path
 import pytest
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__curvature_matrix(rectangular_mapper_7x7_3x3):

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -1,10 +1,10 @@
 import numpy as np
-from os import path
 import pytest
 
 import autoarray as aa
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__has__linear_obj_with_regularization__returns_true():

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -1,20 +1,15 @@
-from os import path
 import autoarray.plot as aplt
 from autoarray.inversion.mappers.abstract import Mapper
 
 import pytest
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "inversion",
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "inversion"
 
 
 def test__individual_attributes_are_output_for_all_mappers(
@@ -30,7 +25,7 @@ def test__individual_attributes_are_output_for_all_mappers(
         output_format="png",
     )
 
-    assert path.join(plot_path, "reconstructed_operated_data.png") in plot_patch.paths
+    assert str(Path(plot_path) / "reconstructed_operated_data.png") in plot_patch.paths
 
     mapper = rectangular_inversion_7x7_3x3.cls_list_from(cls=Mapper)[0]
     pixel_values = rectangular_inversion_7x7_3x3.reconstruction_dict[mapper]
@@ -43,7 +38,7 @@ def test__individual_attributes_are_output_for_all_mappers(
         output_format="png",
     )
 
-    assert path.join(plot_path, "reconstruction.png") in plot_patch.paths
+    assert str(Path(plot_path) / "reconstruction.png") in plot_patch.paths
 
 
 def test__inversion_subplot_of_mapper__is_output_for_all_inversions(
@@ -58,7 +53,7 @@ def test__inversion_subplot_of_mapper__is_output_for_all_inversions(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "inversion_0.png") in plot_patch.paths
+    assert str(Path(plot_path) / "inversion_0.png") in plot_patch.paths
 
     aplt.subplot_mappings(
         inversion=rectangular_inversion_7x7_3x3,
@@ -66,4 +61,4 @@ def test__inversion_subplot_of_mapper__is_output_for_all_inversions(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "mappings_0.png") in plot_patch.paths
+    assert str(Path(plot_path) / "mappings_0.png") in plot_patch.paths

--- a/test_autoarray/inversion/plot/test_mapper_plotters.py
+++ b/test_autoarray/inversion/plot/test_mapper_plotters.py
@@ -1,17 +1,15 @@
-from os import path
 import pytest
 
 import autoarray as aa
 import autoarray.plot as aplt
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "structures"
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "structures"
 
 
 def test__plot_mapper(
@@ -27,7 +25,7 @@ def test__plot_mapper(
         output_format="png",
     )
 
-    assert path.join(plot_path, "mapper1.png") in plot_patch.paths
+    assert str(Path(plot_path) / "mapper1.png") in plot_patch.paths
 
 
 def test__subplot_image_and_mapper(
@@ -43,4 +41,4 @@ def test__subplot_image_and_mapper(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "image_and_mapper.png") in plot_patch.paths
+    assert str(Path(plot_path) / "image_and_mapper.png") in plot_patch.paths

--- a/test_autoarray/mask/test_mask_1d.py
+++ b/test_autoarray/mask/test_mask_1d.py
@@ -1,13 +1,11 @@
 import numpy as np
-from os import path
+from pathlib import Path
 import pytest
 
 import autoarray as aa
 from autoarray import exc
 
-test_data_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))), "files", "mask"
-)
+test_data_path = Path(__file__).resolve().parent / "files" / "mask"
 
 
 # ---------------------------------------------------------------------------

--- a/test_autoarray/mask/test_mask_2d.py
+++ b/test_autoarray/mask/test_mask_2d.py
@@ -1,16 +1,14 @@
 from astropy.io import fits
 import os
-from os import path
 import numpy as np
 import pytest
 import shutil
 
 import autoarray as aa
 from autoarray import exc
+from pathlib import Path
 
-test_data_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))), "files", "mask"
-)
+test_data_path = Path(Path(__file__).resolve().parent) / "files" / "mask"
 
 
 # ---------------------------------------------------------------------------
@@ -375,19 +373,14 @@ def test__from_pixel_coordinates__two_coordinates_buffer_1__two_separate_unmaske
 
 def test__from_fits__output_to_fits__roundtrip_preserves_values_pixel_scales_and_header():
     mask = aa.Mask2D.from_fits(
-        file_path=path.join(test_data_path, "3x3_ones.fits"),
+        file_path=Path(test_data_path) / "3x3_ones.fits",
         hdu=0,
         pixel_scales=(1.0, 1.0),
     )
 
-    output_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "array",
-        "output_test",
-    )
+    output_path = Path(Path(__file__).resolve().parent) / "files" / "array" / "output_test"
 
-    if path.exists(output_path):
+    if Path(output_path).exists():
         shutil.rmtree(output_path)
 
     os.makedirs(output_path)
@@ -395,13 +388,13 @@ def test__from_fits__output_to_fits__roundtrip_preserves_values_pixel_scales_and
     from autoconf.fitsable import output_to_fits
     output_to_fits(
         values=mask.astype("float"),
-        file_path=path.join(output_path, "mask.fits"),
+        file_path=Path(output_path) / "mask.fits",
         header_dict=mask.header_dict,
         ext_name="mask",
     )
 
     mask = aa.Mask2D.from_fits(
-        file_path=path.join(output_path, "mask.fits"),
+        file_path=Path(output_path) / "mask.fits",
         hdu=0,
         pixel_scales=(1.0, 1.0),
         origin=(2.0, 2.0),
@@ -411,7 +404,7 @@ def test__from_fits__output_to_fits__roundtrip_preserves_values_pixel_scales_and
     assert mask.pixel_scales == (1.0, 1.0)
     assert mask.origin == (2.0, 2.0)
 
-    header = aa.header_obj_from(file_path=path.join(output_path, "mask.fits"), hdu=0)
+    header = aa.header_obj_from(file_path=Path(output_path) / "mask.fits", hdu=0)
 
     assert header["PIXSCAY"] == 1.0
     assert header["PIXSCAX"] == 1.0
@@ -424,7 +417,7 @@ def test__from_fits__with_resized_mask_shape__output_shape_matches_requested_sha
     resized_shape,
 ):
     mask = aa.Mask2D.from_fits(
-        file_path=path.join(test_data_path, "3x3_ones.fits"),
+        file_path=Path(test_data_path) / "3x3_ones.fits",
         hdu=0,
         pixel_scales=(1.0, 1.0),
         resized_mask_shape=resized_shape,

--- a/test_autoarray/operators/test_convolver.py
+++ b/test_autoarray/operators/test_convolver.py
@@ -3,11 +3,11 @@ from astropy.modeling import functional_models
 from astropy.coordinates import Angle
 import numpy as np
 import pytest
-from os import path
 
 import autoarray as aa
+from pathlib import Path
 
-test_data_path = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+test_data_path = Path(Path(__file__).resolve().parent) / "files"
 
 
 @pytest.mark.parametrize(

--- a/test_autoarray/plot/test_output.py
+++ b/test_autoarray/plot/test_output.py
@@ -1,10 +1,10 @@
 import autoarray.plot as aplt
 
-from os import path
+from pathlib import Path
 
 import shutil
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__constructor():
@@ -22,17 +22,17 @@ def test__constructor():
     assert output.format == "png"
     assert output.filename == "file"
 
-    if path.exists(output.path):
+    if Path(output.path).exists():
         shutil.rmtree(output.path)
 
 
 def test__input_path_is_created():
-    test_path = path.join(directory, "files", "output_path")
+    test_path = str(directory / "files" / "output_path")
 
-    if path.exists(test_path):
+    if Path(test_path).exists():
         shutil.rmtree(test_path)
 
-    assert not path.exists(test_path)
+    assert not Path(test_path).exists()
 
     output = aplt.Output(
         path=test_path,
@@ -40,4 +40,4 @@ def test__input_path_is_created():
     )
     output.to_figure(structure=None, auto_filename="test")
 
-    assert path.exists(test_path)
+    assert Path(test_path).exists()

--- a/test_autoarray/structures/arrays/test_array_1d_util.py
+++ b/test_autoarray/structures/arrays/test_array_1d_util.py
@@ -2,12 +2,9 @@ import autoarray as aa
 import numpy as np
 import pytest
 
-import os
-from os import path
+from pathlib import Path
 
-test_data_path = os.path.join(
-    "{}".format(os.path.dirname(os.path.realpath(__file__))), "files"
-)
+test_data_path = Path(__file__).resolve().parent / "files"
 
 
 def test__array_1d_slim_from():

--- a/test_autoarray/structures/arrays/test_array_2d_util.py
+++ b/test_autoarray/structures/arrays/test_array_2d_util.py
@@ -1,12 +1,10 @@
 from autoarray import util
 
-import os
+from pathlib import Path
 import numpy as np
 
 
-test_data_path = os.path.join(
-    "{}".format(os.path.dirname(os.path.realpath(__file__))), "files"
-)
+test_data_path = Path(__file__).resolve().parent / "files"
 
 
 def test__resized_array_2d_from__trimming():

--- a/test_autoarray/structures/arrays/test_irregular.py
+++ b/test_autoarray/structures/arrays/test_irregular.py
@@ -1,9 +1,9 @@
-from os import path
+from pathlib import Path
 
 import numpy as np
 import autoarray as aa
 
-test_values_dir = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+test_values_dir = Path(__file__).resolve().parent / "files"
 
 
 def test__input_as_list__convert_correctly():

--- a/test_autoarray/structures/arrays/test_uniform_1d.py
+++ b/test_autoarray/structures/arrays/test_uniform_1d.py
@@ -1,5 +1,5 @@
 from astropy.io import fits
-from os import path
+from pathlib import Path
 import os
 import numpy as np
 import pytest
@@ -7,19 +7,15 @@ import shutil
 
 import autoarray as aa
 
-fits_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))), "files", "array_1d"
-)
+fits_path = Path(__file__).resolve().parent / "files" / "array_1d"
 
-test_data_path = path.join(
-    "{}".format(path.dirname(path.realpath(__file__))), "files", "array", "output_test"
-)
+test_data_path = Path(__file__).resolve().parent / "files" / "array" / "output_test"
 
 
 def create_fits(
     fits_path,
 ):
-    if path.exists(fits_path):
+    if Path(fits_path).exists():
         shutil.rmtree(fits_path)
 
     os.makedirs(fits_path)
@@ -27,16 +23,16 @@ def create_fits(
     hdu_list = fits.HDUList()
     hdu_list.append(fits.ImageHDU(np.ones(3)))
     hdu_list[0].header.set("BITPIX", -64, "")
-    hdu_list.writeto(path.join(fits_path, "3_ones.fits"))
+    hdu_list.writeto(Path(fits_path) / "3_ones.fits")
 
     hdu_list = fits.HDUList()
     hdu_list.append(fits.ImageHDU(np.ones(4)))
     hdu_list[0].header.set("BITPIX", -64, "")
-    hdu_list.writeto(path.join(fits_path, "4_ones.fits"))
+    hdu_list.writeto(Path(fits_path) / "4_ones.fits")
 
 
 def clean_fits(fits_path):
-    if path.exists(fits_path):
+    if Path(fits_path).exists():
         shutil.rmtree(fits_path)
 
 
@@ -107,7 +103,7 @@ def test__from_fits__3_element_fits__native_and_slim_are_ones():
     create_fits(fits_path=fits_path)
 
     arr = aa.Array1D.from_fits(
-        file_path=path.join(fits_path, "3_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=fits_path / "3_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert type(arr) == aa.Array1D
@@ -121,7 +117,7 @@ def test__from_fits__4_element_fits__native_slim_and_array_are_ones():
     create_fits(fits_path=fits_path)
 
     arr = aa.Array1D.from_fits(
-        file_path=path.join(fits_path, "4_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=fits_path / "4_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert type(arr) == aa.Array1D
@@ -136,7 +132,7 @@ def test__from_fits__3_element_fits__header_bitpix_is_minus_64():
     create_fits(fits_path=fits_path)
 
     arr = aa.Array1D.from_fits(
-        file_path=path.join(fits_path, "3_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=fits_path / "3_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert arr.header.header_sci_obj["BITPIX"] == -64
@@ -149,7 +145,7 @@ def test__from_fits__4_element_fits__header_bitpix_is_minus_64():
     create_fits(fits_path=fits_path)
 
     arr = aa.Array1D.from_fits(
-        file_path=path.join(fits_path, "4_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=fits_path / "4_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert arr.header.header_sci_obj["BITPIX"] == -64
@@ -161,22 +157,22 @@ def test__from_fits__4_element_fits__header_bitpix_is_minus_64():
 def test__output_to_fits__ones_array__fits_file_has_correct_values_and_header():
     arr = aa.Array1D.ones(shape_native=(3,), pixel_scales=1.0)
 
-    if path.exists(test_data_path):
+    if test_data_path.exists():
         shutil.rmtree(test_data_path)
 
     os.makedirs(test_data_path)
 
     from autoconf.fitsable import output_to_fits
-    output_to_fits(values=arr.native.array.astype("float"), file_path=path.join(test_data_path, "array.fits"), header_dict=arr.mask.header_dict)
+    output_to_fits(values=arr.native.array.astype("float"), file_path=test_data_path / "array.fits", header_dict=arr.mask.header_dict)
 
     array_from_out = aa.Array1D.from_fits(
-        file_path=path.join(test_data_path, "array.fits"), hdu=0, pixel_scales=1.0
+        file_path=test_data_path / "array.fits", hdu=0, pixel_scales=1.0
     )
 
     assert (array_from_out.native == np.ones((3,))).all()
 
     header_load = aa.header_obj_from(
-        file_path=path.join(test_data_path, "array.fits"), hdu=0
+        file_path=test_data_path / "array.fits", hdu=0
     )
 
     assert header_load["PIXSCA"] == 1.0

--- a/test_autoarray/structures/arrays/test_uniform_2d.py
+++ b/test_autoarray/structures/arrays/test_uniform_2d.py
@@ -1,6 +1,6 @@
 from astropy.io import fits
 import os
-from os import path
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -8,9 +8,7 @@ import shutil
 
 import autoarray as aa
 
-test_data_path = path.join(
-    "{}".format(os.path.dirname(os.path.realpath(__file__))), "files"
-)
+test_data_path = Path(__file__).resolve().parent / "files"
 
 
 def test__constructor__2x2_all_false_mask__native_matches_input_2d_values():
@@ -143,7 +141,7 @@ def test__zeros__2x2_shape__all_native_elements_are_zero():
 
 def test__from_fits__4x3_ones_fits__native_is_ones_array():
     array_2d = aa.Array2D.from_fits(
-        file_path=path.join(test_data_path, "4x3_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=test_data_path / "4x3_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert type(array_2d) == aa.Array2D
@@ -153,7 +151,7 @@ def test__from_fits__4x3_ones_fits__native_is_ones_array():
 
 def test__from_fits__3x3_fits__header_bitpix_stored_correctly():
     array_2d = aa.Array2D.from_fits(
-        file_path=path.join(test_data_path, "3x3_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=test_data_path / "3x3_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert array_2d.header.header_sci_obj["BITPIX"] == -64
@@ -162,7 +160,7 @@ def test__from_fits__3x3_fits__header_bitpix_stored_correctly():
 
 def test__from_fits__4x3_fits__header_bitpix_stored_correctly():
     array_2d = aa.Array2D.from_fits(
-        file_path=path.join(test_data_path, "4x3_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=test_data_path / "4x3_ones.fits", hdu=0, pixel_scales=1.0
     )
 
     assert array_2d.header.header_sci_obj["BITPIX"] == -64
@@ -194,30 +192,23 @@ def test__from_yx_and_values__3x2_grid__native_matches_expected_pixel_layout():
 
 
 def test__output_to_fits__3x3_ones__fits_file_has_ones_and_correct_pixel_scale_header():
-    test_data_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files"
-    )
+    files_path = Path(__file__).resolve().parent / "files"
 
     array_2d = aa.Array2D.from_fits(
-        file_path=path.join(test_data_path, "3x3_ones.fits"), hdu=0, pixel_scales=1.0
+        file_path=files_path / "3x3_ones.fits", hdu=0, pixel_scales=1.0
     )
 
-    test_data_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "array",
-        "output_test",
-    )
-    if path.exists(test_data_path):
-        shutil.rmtree(test_data_path)
+    output_test_path = files_path / "array" / "output_test"
+    if output_test_path.exists():
+        shutil.rmtree(output_test_path)
 
-    os.makedirs(test_data_path)
+    os.makedirs(output_test_path)
 
     from autoconf.fitsable import output_to_fits
-    output_to_fits(values=array_2d.native.array.astype("float"), file_path=path.join(test_data_path, "array.fits"), header_dict=array_2d.mask.header_dict)
+    output_to_fits(values=array_2d.native.array.astype("float"), file_path=output_test_path / "array.fits", header_dict=array_2d.mask.header_dict)
 
     array_from_fits = aa.Array2D.from_fits(
-        file_path=path.join(test_data_path, "array.fits"), hdu=0, pixel_scales=1.0
+        file_path=output_test_path / "array.fits", hdu=0, pixel_scales=1.0
     )
 
     assert (array_from_fits.native == np.ones((3, 3))).all()

--- a/test_autoarray/structures/grids/test_irregular_2d.py
+++ b/test_autoarray/structures/grids/test_irregular_2d.py
@@ -1,5 +1,4 @@
 import os
-from os import path
 import shutil
 import numpy as np
 

--- a/test_autoarray/structures/grids/test_uniform_1d.py
+++ b/test_autoarray/structures/grids/test_uniform_1d.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 import numpy as np
 import pytest
 

--- a/test_autoarray/structures/grids/test_uniform_2d.py
+++ b/test_autoarray/structures/grids/test_uniform_2d.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 import numpy as np
 import pytest
 
@@ -6,7 +6,7 @@ from autoconf import conf
 import autoarray as aa
 from autoarray import exc
 
-test_grid_dir = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+test_grid_dir = Path(__file__).resolve().parent / "files"
 
 
 def test__constructor__2x2_all_false_mask__native_slim_and_pixel_scales_correct():
@@ -473,7 +473,7 @@ def test__from_mask():
 def test__to_and_from_fits_methods():
     grid_2d = aa.Grid2D.uniform(shape_native=(2, 2), pixel_scales=2.0)
 
-    file_path = path.join(test_grid_dir, "grid_2d.fits")
+    file_path = test_grid_dir / "grid_2d.fits"
 
     from autoconf.fitsable import output_to_fits
     output_to_fits(values=grid_2d.native.array.astype("float"), file_path=file_path, overwrite=True, header_dict=grid_2d.mask.header_dict)

--- a/test_autoarray/structures/plot/test_structure_plotters.py
+++ b/test_autoarray/structures/plot/test_structure_plotters.py
@@ -1,18 +1,16 @@
 import autoarray as aa
 import autoarray.plot as aplt
-from os import path
 import pytest
 import numpy as np
 import shutil
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plot_path_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "structures"
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "structures"
 
 
 def test__plot_yx_line(plot_path, plot_patch):
@@ -25,7 +23,7 @@ def test__plot_yx_line(plot_path, plot_patch):
         plot_axis_type="loglog",
     )
 
-    assert path.join(plot_path, "yx_1.png") in plot_patch.paths
+    assert str(Path(plot_path) / "yx_1.png") in plot_patch.paths
 
 
 def test__array(
@@ -43,7 +41,7 @@ def test__array(
         output_format="png",
     )
 
-    assert path.join(plot_path, "array1.png") in plot_patch.paths
+    assert str(Path(plot_path) / "array1.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=array_2d_7x7,
@@ -52,7 +50,7 @@ def test__array(
         output_format="png",
     )
 
-    assert path.join(plot_path, "array2.png") in plot_patch.paths
+    assert str(Path(plot_path) / "array2.png") in plot_patch.paths
 
     aplt.plot_array_2d(
         array=array_2d_7x7,
@@ -66,7 +64,7 @@ def test__array(
         output_format="png",
     )
 
-    assert path.join(plot_path, "array3.png") in plot_patch.paths
+    assert str(Path(plot_path) / "array3.png") in plot_patch.paths
 
 
 def test__grid(
@@ -88,7 +86,7 @@ def test__grid(
         color_array=color_array,
     )
 
-    assert path.join(plot_path, "grid1.png") in plot_patch.paths
+    assert str(Path(plot_path) / "grid1.png") in plot_patch.paths
 
     aplt.plot_grid_2d(
         grid=grid_2d_7x7,
@@ -99,7 +97,7 @@ def test__grid(
         color_array=color_array,
     )
 
-    assert path.join(plot_path, "grid2.png") in plot_patch.paths
+    assert str(Path(plot_path) / "grid2.png") in plot_patch.paths
 
     aplt.plot_grid_2d(
         grid=grid_2d_7x7,
@@ -111,7 +109,7 @@ def test__grid(
         color_array=color_array,
     )
 
-    assert path.join(plot_path, "grid3.png") in plot_patch.paths
+    assert str(Path(plot_path) / "grid3.png") in plot_patch.paths
 
 
 def test__array_rgb(
@@ -126,7 +124,7 @@ def test__array_rgb(
         output_format="png",
     )
 
-    assert path.join(plot_path, "array_rgb.png") in plot_patch.paths
+    assert str(Path(plot_path) / "array_rgb.png") in plot_patch.paths
 
 
 def test__plot_array_rgb(
@@ -147,4 +145,4 @@ def test__plot_array_rgb(
         output_format="png",
     )
 
-    assert path.join(plot_path, "array_rgb_high_level.png") in plot_patch.paths
+    assert str(Path(plot_path) / "array_rgb_high_level.png") in plot_patch.paths

--- a/test_autoarray/structures/test_visibilities.py
+++ b/test_autoarray/structures/test_visibilities.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 import numpy as np
 import pytest
 import shutil
@@ -7,7 +7,7 @@ import shutil
 import autoarray as aa
 from autoarray.structures import visibilities as vis
 
-test_data_path = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+test_data_path = Path(__file__).resolve().parent / "files"
 
 
 def test__manual__makes_visibilities_without_other_inputs():
@@ -72,14 +72,14 @@ def test__ones_zeros__makes_visibilities_without_other_inputs():
 
 def test__from_fits__makes_visibilities_without_other_inputs():
     visibilities = aa.Visibilities.from_fits(
-        file_path=path.join(test_data_path, "3x2_ones.fits"), hdu=0
+        file_path=test_data_path / "3x2_ones.fits", hdu=0
     )
 
     assert type(visibilities) == vis.Visibilities
     assert (visibilities.slim == np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])).all()
 
     visibilities = aa.Visibilities.from_fits(
-        file_path=path.join(test_data_path, "3x2_twos.fits"), hdu=0
+        file_path=test_data_path / "3x2_twos.fits", hdu=0
     )
 
     assert type(visibilities) == vis.Visibilities
@@ -87,26 +87,24 @@ def test__from_fits__makes_visibilities_without_other_inputs():
 
 
 def test__output_to_fits():
-    test_data_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files"
-    )
+    files_path = Path(__file__).resolve().parent / "files"
 
     visibilities = aa.Visibilities.from_fits(
-        file_path=path.join(test_data_path, "3x2_ones.fits"), hdu=0
+        file_path=files_path / "3x2_ones.fits", hdu=0
     )
 
-    test_data_path = path.join(test_data_path, "output_test")
+    output_test_path = files_path / "output_test"
 
-    if path.exists(test_data_path):
-        shutil.rmtree(test_data_path)
+    if output_test_path.exists():
+        shutil.rmtree(output_test_path)
 
-    os.makedirs(test_data_path)
+    os.makedirs(output_test_path)
 
     from autoconf.fitsable import output_to_fits
-    output_to_fits(values=visibilities.in_array, file_path=path.join(test_data_path, "data.fits"))
+    output_to_fits(values=visibilities.in_array, file_path=output_test_path / "data.fits")
 
     visibilities_from_out = aa.Visibilities.from_fits(
-        file_path=path.join(test_data_path, "data.fits"), hdu=0
+        file_path=output_test_path / "data.fits", hdu=0
     )
     assert (
         visibilities_from_out.slim == np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])

--- a/test_autoarray/structures/vectors/test_vectors_irregular.py
+++ b/test_autoarray/structures/vectors/test_vectors_irregular.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 from matplotlib.patches import Ellipse
 import pytest


### PR DESCRIPTION
## Summary

Mechanical refactor replacing all `os.path.*` and bare `path.*` (from `from os import path`) usages with `pathlib.Path`. Part of cross-repo issue PyAutoLabs/PyAutoFit#1257 — the codebase already used `pathlib` extensively in newer code; this sweeps up the remaining legacy usages for consistency.

## API Changes

None — internal changes only. All public function signatures unchanged. Implementation switches from string-style joins to Path objects, but returned values, accepted argument types, and external behaviour are unchanged. Some test fixtures (`PlotPatch`) now stringify recorded paths to keep assertions stable.

See full details below.

## Test Plan

- [ ] `python -m pytest test_<repo>/` passes (CI)
- [ ] Verified locally as part of cross-repo sweep (3,188 tests across PyAutoConf/PyAutoFit/PyAutoArray/PyAutoGalaxy/PyAutoLens)
- [ ] No public API changed — workspace scripts should be unaffected (separate workspace PR follows for tutorial/example consistency)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None — no public symbols removed

### Added
- None — no new public symbols

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- None observable. Internal helpers now build paths with `Path / "..."` instead of `os.path.join`, but consumers that accept `str | os.PathLike` see the same effective path.

### Migration
- No user migration needed.

</details>

Refs PyAutoLabs/PyAutoFit#1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)