### PR TITLE
fix(inversion): regularization_weights_mapper_dict uses correct linear_obj_list index

### DIFF
--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -802,7 +802,8 @@ class AbstractInversion:
     def regularization_weights_mapper_dict(self) -> Dict[LinearObj, np.ndarray]:
         regularization_weights_dict = {}
 
-        for index, mapper in enumerate(self.cls_list_from(cls=Mapper)):
+        for mapper in self.cls_list_from(cls=Mapper):
+            index = self.linear_obj_list.index(mapper)
             regularization_weights_dict[mapper] = self.regularization_weights_from(
                 index=index,
             )

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -313,6 +313,50 @@ def test__reconstruction_dict__multiple_linear_objs_and_mappers__splits_reconstr
     assert (inversion.reconstruction_dict[mapper_1] == 2.0 * np.ones(3)).all()
 
 
+def test__regularization_weights_mapper_dict__linear_obj_before_mapper__indexes_correctly():
+    # Distinct coefficients identify which linear_obj_list entry each weight set
+    # came from: 7.0 → the non-mapper linear obj at index 0, 11.0 → the mapper
+    # at index 1. A pre-fix `enumerate(cls_list_from(Mapper))` would pass the
+    # mapper-only index 0 into `regularization_weights_from`, which reads
+    # `linear_obj_list[0]` and returns the 2-element 7.0 weights.
+    linear_obj = aa.m.MockLinearObj(
+        parameters=2, regularization=aa.reg.Constant(coefficient=7.0)
+    )
+    mapper = aa.m.MockMapper(
+        parameters=3, regularization=aa.reg.Constant(coefficient=11.0)
+    )
+
+    inversion = aa.m.MockInversion(linear_obj_list=[linear_obj, mapper])
+
+    weights = inversion.regularization_weights_mapper_dict[mapper]
+
+    assert weights.shape == (3,)
+    assert (weights == 11.0 * np.ones(3)).all()
+
+
+def test__regularization_weights_mapper_dict__multiple_mappers_with_linear_obj_between__indexes_correctly():
+    # Layout: [mapper_a (params=2), linear_obj (params=1), mapper_b (params=4)]
+    # Each gets a distinct Constant coefficient to verify per-mapper indexing.
+    mapper_a = aa.m.MockMapper(
+        parameters=2, regularization=aa.reg.Constant(coefficient=3.0)
+    )
+    linear_obj = aa.m.MockLinearObj(
+        parameters=1, regularization=aa.reg.Constant(coefficient=5.0)
+    )
+    mapper_b = aa.m.MockMapper(
+        parameters=4, regularization=aa.reg.Constant(coefficient=13.0)
+    )
+
+    inversion = aa.m.MockInversion(
+        linear_obj_list=[mapper_a, linear_obj, mapper_b],
+    )
+
+    rw_dict = inversion.regularization_weights_mapper_dict
+
+    assert (rw_dict[mapper_a] == 3.0 * np.ones(2)).all()
+    assert (rw_dict[mapper_b] == 13.0 * np.ones(4)).all()
+
+
 def test__mapped_reconstructed_data_dict__single_linear_obj__returns_correct_data_and_sum():
     linear_obj_0 = aa.m.MockLinearObj()
 


### PR DESCRIPTION
## Summary

Fixes `AbstractInversion.regularization_weights_mapper_dict` mis-indexing when a non-Mapper linear object precedes a source `Mapper` in `linear_obj_list`. The mapper's dict slot was being populated with the regularization weights of whichever `linear_obj_list[i]` happened to share its enumerated position in the Mapper-only sublist — for a typical MGE-lens-light + pixelized-source layout, that meant the 40-element lens MGE weights ended up keyed under a 530-pixel source mapper. matplotlib's `ax.tripcolor` then refused to render the source-plane regularization-weights subplot in `inversion_0_0.png`, logging `Could not plot the source-plane via the Mapper: The length of c must match either the number of points or the number of triangles`. The numerical reconstruction itself was unaffected.

## API Changes

None — internal indexing fix in `AbstractInversion.regularization_weights_mapper_dict`. The property's signature and return type are unchanged; the dict now correctly maps each `Mapper` to its own regularization weights when other linear objects sit ahead of it in `linear_obj_list`. See full details below.

## Test Plan

- [x] `python -m pytest test_autoarray/inversion/inversion/test_abstract.py -k regularization_weights_mapper_dict -v` — two new regression tests pass.
- [x] `python -m pytest test_autoarray/inversion/` — full inversion suite (164 tests) green.
- [x] End-to-end verified: re-running an Euclid `vis_pix` Nautilus fit no longer emits `Could not plot the source-plane via the Mapper` log lines.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- `autoarray.inversion.inversion.abstract.AbstractInversion.regularization_weights_mapper_dict` — when `linear_obj_list` contains non-Mapper entries (e.g. `LightProfileLinearObjFuncList`) ahead of a `Mapper`, the dict slot for that mapper now contains the mapper's own regularization weights rather than the weights of whichever linear obj happened to share its Mapper-only enumerate index. Inversions whose `linear_obj_list` starts with a `Mapper` produced correct output before and after this change.

### Migration
- None required. Public API is unchanged.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)