### PR TITLE
fix(interferometer-sparse): guard against Delaunay mappers (issue #314)

### DIFF
--- a/autoarray/inversion/inversion/interferometer/sparse.py
+++ b/autoarray/inversion/inversion/interferometer/sparse.py
@@ -7,6 +7,7 @@ from autoarray.inversion.inversion.interferometer.abstract import (
     AbstractInversionInterferometer,
 )
 from autoarray.inversion.linear_obj.linear_obj import LinearObj
+from autoarray.inversion.mesh.mesh.delaunay import Delaunay
 from autoarray.settings import Settings
 from autoarray.inversion.mappers.abstract import Mapper
 from autoarray.structures.visibilities import Visibilities
@@ -100,6 +101,27 @@ class InversionInterferometerSparse(AbstractInversionInterferometer):
         """
 
         mapper = self.cls_list_from(cls=Mapper)[0]
+
+        # The interferometer sparse-operator curvature path
+        # (``InterferometerSparseOperator.curvature_matrix_via_sparse_operator_from``)
+        # has only been validated against ``Rectangular*`` meshes (single source
+        # pixel per image pixel, weight=1). When given a ``Delaunay`` mapper
+        # (three source pixels per image pixel via barycentric interpolation,
+        # weights summing to 1) the returned curvature matrix disagrees with the
+        # mapping path by ~34% Frobenius and the regularized matrix loses
+        # positive-definiteness, raising a numpy ``LinAlgError`` at the Cholesky
+        # call site in ``Inversion.log_det_curvature_reg_matrix_term``. Guard
+        # rather than silently mis-computing.
+        if isinstance(mapper.mesh, Delaunay):
+            raise NotImplementedError(
+                "Interferometer.apply_sparse_operator() is not implemented for "
+                "Delaunay-mesh pixelizations: the sparse curvature math has only "
+                "been validated against Rectangular meshes (Pmax=1, weight=1) "
+                "and is structurally wrong for barycentric-interpolated mappers "
+                "(Pmax=3). For Delaunay interferometer fits, use the plain DFT "
+                "or NUFFT path (i.e. omit the apply_sparse_operator step). "
+                "Tracking issue: https://github.com/PyAutoLabs/PyAutoArray/issues/314"
+            )
 
         return self.dataset.sparse_operator.curvature_matrix_via_sparse_operator_from(
             pix_indexes_for_sub_slim_index=mapper.pix_indexes_for_sub_slim_index,

--- a/test_autoarray/inversion/inversion/interferometer/test_interferometer.py
+++ b/test_autoarray/inversion/inversion/interferometer/test_interferometer.py
@@ -62,3 +62,73 @@ def test__fast_chi_squared(
     chi_squared = aa.util.fit.chi_squared_complex_from(chi_squared_map=chi_squared_map)
 
     assert inversion.fast_chi_squared == pytest.approx(chi_squared, 1.0e-4)
+
+
+def test__apply_sparse_operator__delaunay_mapper__raises_not_implemented():
+    """``InversionInterferometerSparse.curvature_matrix_diag`` must raise a
+    ``NotImplementedError`` rather than silently mis-computing when paired
+    with a Delaunay mapper.
+
+    The interferometer sparse-operator curvature path
+    (``InterferometerSparseOperator.curvature_matrix_via_sparse_operator_from``)
+    was only validated against ``Rectangular*`` meshes (single source pixel per
+    image pixel, weight 1). On a Delaunay mapper (three source pixels per image
+    pixel via barycentric interpolation, weights summing to 1) the returned
+    curvature matrix disagrees with the mapping path by ~34% Frobenius norm and
+    the regularized matrix loses positive-definiteness, raising a numpy
+    ``LinAlgError`` deep inside ``Inversion.log_det_curvature_reg_matrix_term``.
+    The guard at the entry point catches the mis-use early with a clear message.
+    """
+    mask = aa.Mask2D(
+        mask=[
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, False, True, True, True],
+            [True, True, False, False, False, True, True],
+            [True, True, True, False, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+        ],
+        pixel_scales=2.0,
+    )
+
+    grid = aa.Grid2D.from_mask(mask=mask, over_sample_size=1)
+
+    mesh = aa.mesh.Delaunay(pixels=9)
+    image_mesh = aa.image_mesh.Overlay(shape=(3, 3))
+    image_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+        mask=mask, adapt_data=None
+    )
+
+    interpolator = mesh.interpolator_from(
+        source_plane_data_grid=grid,
+        source_plane_mesh_grid=image_mesh_grid,
+    )
+    mapper = aa.Mapper(interpolator=interpolator)
+
+    n_visibilities = 5
+    rng = np.random.default_rng(seed=0)
+    data = aa.Visibilities(
+        visibilities=rng.normal(size=(n_visibilities, 2)).astype(np.float64)
+    )
+    noise_map = aa.VisibilitiesNoiseMap(
+        visibilities=np.ones((n_visibilities, 2), dtype=np.float64)
+    )
+    uv_wavelengths = rng.normal(size=(n_visibilities, 2)).astype(np.float64)
+
+    dataset = aa.Interferometer(
+        data=data,
+        noise_map=noise_map,
+        uv_wavelengths=uv_wavelengths,
+        real_space_mask=mask,
+        transformer_class=aa.TransformerDFT,
+    )
+    dataset_sparse = dataset.apply_sparse_operator(use_jax=False)
+
+    inversion = aa.Inversion(
+        dataset=dataset_sparse,
+        linear_obj_list=[mapper],
+    )
+
+    with pytest.raises(NotImplementedError, match=r"Delaunay"):
+        _ = inversion.curvature_matrix


### PR DESCRIPTION
## Summary

Guards `InversionInterferometerSparse.curvature_matrix_diag` against Delaunay mappers with a clear `NotImplementedError` instead of silently producing a wrong curvature matrix. Surfaced while attempting to enable `dataset.apply_sparse_operator(use_jax=True)` on Hannah Stacey's ALMA cube profiler (shipped #311 / autolens_workspace_developer#63): the sparse-operator curvature disagrees with the mapping path by **~34% Frobenius norm** for Delaunay, the regularized matrix loses positive-definiteness, and `Inversion.log_det_curvature_reg_matrix_term` raises `numpy.linalg.LinAlgError`.

The underlying math bug is filed as #314 — that issue tracks the actual fix. This PR is just the silent-failure guard.

## API Changes

`InversionInterferometerSparse.curvature_matrix_diag` (and therefore `curvature_matrix`, `data_vector`, and any downstream method that materialises the curvature) now raises `NotImplementedError` when constructed with a Delaunay-mesh mapper. Users running `Interferometer.apply_sparse_operator(...)` + Delaunay get a clear early failure pointing at #314 instead of a confusing Cholesky error deep inside the inversion solver. See full details below.

## Test Plan

- [x] `pytest test_autoarray/inversion/inversion/interferometer/test_interferometer.py -xvs` — 3 passed (existing 2 + new `test__apply_sparse_operator__delaunay_mapper__raises_not_implemented`).
- [x] `pytest test_autoarray/inversion/` — 165 passed.
- [ ] CI green.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `autoarray.inversion.inversion.interferometer.sparse.InversionInterferometerSparse.curvature_matrix_diag` — now raises `NotImplementedError` when the first mapper in `linear_obj_list` uses a `Delaunay` mesh. The previous behaviour returned a numerically-incorrect curvature matrix (~34% Frobenius disagreement with the mapping path) and downstream operations failed loudly in the Cholesky factorisation step. After this PR the failure surfaces at the construction of the curvature matrix itself with a message pointing at issue #314.

### Migration

For Delaunay interferometer fits that previously called `dataset.apply_sparse_operator(...)`, drop the call and use the plain `TransformerDFT` (or `TransformerNUFFT`) path directly:

```python
# Before — silently wrong then crashes at Cholesky
dataset = al.Interferometer.from_fits(..., transformer_class=al.TransformerDFT)
dataset = dataset.apply_sparse_operator(use_jax=True)  # Delaunay path

# After — no sparse-operator for Delaunay; use the plain DFT path
dataset = al.Interferometer.from_fits(..., transformer_class=al.TransformerDFT)
# (no apply_sparse_operator call — eager and JIT both work)
```

Rectangular interferometer fits are unaffected — they continue to work with `apply_sparse_operator` (the optimisation is validated for Rectangular meshes).

</details>

## Related

- Tracking issue (the real math fix): #314
- Surfaced from datacube-sparse-operator profiler work: #311, autolens_workspace_developer#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)