### PR TITLE
Reduce critical curves and caustics overlay linewidth from 2 to 1

### DIFF
--- a/autoarray/plot/array.py
+++ b/autoarray/plot/array.py
@@ -267,7 +267,7 @@ def plot_array(
             if line is not None and len(line) > 0:
                 line = np.asarray(line).reshape(-1, 2)
                 color = line_colors[i] if (line_colors is not None and i < len(line_colors)) else None
-                kw = {"linewidth": 2}
+                kw = {"linewidth": 1}
                 if color is not None:
                     kw["color"] = color
                 ax.plot(line[:, 1], line[:, 0], **kw)

--- a/autoarray/plot/grid.py
+++ b/autoarray/plot/grid.py
@@ -151,7 +151,7 @@ def plot_grid(
     if lines is not None:
         for line in lines:
             if line is not None and len(line) > 0:
-                ax.plot(line[:, 1], line[:, 0], linewidth=2)
+                ax.plot(line[:, 1], line[:, 0], linewidth=1)
 
     # --- labels ----------------------------------------------------------------
     apply_labels(ax, title=title, xlabel=xlabel, ylabel=ylabel)

--- a/autoarray/plot/inversion.py
+++ b/autoarray/plot/inversion.py
@@ -126,7 +126,7 @@ def plot_inversion_reconstruction(
             if line is not None and len(line) > 0:
                 line = np.asarray(line).reshape(-1, 2)
                 color = line_colors[i] if (line_colors is not None and i < len(line_colors)) else None
-                kw = {"linewidth": 2}
+                kw = {"linewidth": 1}
                 if color is not None:
                     kw["color"] = color
                 ax.plot(line[:, 1], line[:, 0], **kw)


### PR DESCRIPTION
## Summary
Reduces the matplotlib `linewidth` used for the `lines=` overlay in `plot_array`, `plot_inversion_reconstruction`, and `plot_grid` from `2` to `1`. In current usage these overlays are exclusively critical curves and caustics, which users reported were too thick to inspect underlying lens-model results (convergence, potential, deflections, and source-plane reconstructions).

## API Changes
None — internal styling tweak only. No public symbols added, removed, renamed, or re-signatured; the `lines=` parameter and all call sites in PyAutoGalaxy / PyAutoLens are unchanged. Behaviour change is limited to rendered line thickness.
See full details below.

## Test Plan
- [ ] `python -m pytest test_autoarray/ -x` passes
- [ ] Run an autolens workspace script that produces critical-curve overlays (e.g. `PYAUTO_OUTPUT_MODE=1 python autolens_workspace/scripts/imaging/modeling/start_here.py`) and visually confirm the white tangential and yellow radial overlays are noticeably thinner without otherwise changing the figures.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None

### Added
- None

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- `autoarray.plot.plot_array(..., lines=...)` — overlay lines now render at `linewidth=1` (was `2`).
- `autoarray.plot.plot_inversion_reconstruction(..., lines=...)` — overlay lines now render at `linewidth=1` (was `2`).
- `autoarray.plot.plot_grid(..., lines=...)` — overlay lines now render at `linewidth=1` (was `2`).

### Migration
- None required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)