### PR TITLE
fix(inversion): make AbstractMeshGeometry picklable (xp module → _use_jax bool + property)

### DIFF
--- a/autoarray/inversion/mesh/mesh_geometry/abstract.py
+++ b/autoarray/inversion/mesh/mesh_geometry/abstract.py
@@ -20,4 +20,11 @@ class AbstractMeshGeometry:
         # When non-None, rectangular geometry uses the spline-CDF helpers
         # instead of the linear-interp CDF (areas / edges transforms only).
         self.spline_deg = spline_deg
-        self._xp = xp
+        self._use_jax = xp is not np
+
+    @property
+    def _xp(self):
+        if self._use_jax:
+            import jax.numpy as jnp
+            return jnp
+        return np

--- a/test_autoarray/inversion/pixelization/mesh_geometry/test_picklability.py
+++ b/test_autoarray/inversion/pixelization/mesh_geometry/test_picklability.py
@@ -1,0 +1,77 @@
+"""Pickle round-trip tests for AbstractMeshGeometry subclasses.
+
+Required by subprocess visualization (PyAutoFit #1279, Phase 4 of the JAX
+visualization roadmap). A populated FitImaging must be sendable over an
+mp.Process+Queue or ProcessPoolExecutor boundary — historically blocked
+by `self._xp = xp` (module attribute) on AbstractMeshGeometry, since
+Python's pickle cannot serialise module references.
+
+Fix: `_xp` is now a property derived from a boolean `_use_jax` flag.
+This file is the regression test for that invariant.
+"""
+
+import importlib.util
+import pickle
+
+import numpy as np
+import pytest
+
+from autoarray.inversion.mesh.mesh_geometry.rectangular import MeshGeometryRectangular
+from autoarray.inversion.mesh.mesh_geometry.delaunay import MeshGeometryDelaunay
+
+
+def _jax_installed() -> bool:
+    return importlib.util.find_spec("jax") is not None
+
+
+@pytest.mark.parametrize("cls", [MeshGeometryRectangular, MeshGeometryDelaunay])
+def test_pickle_round_trip_numpy_backend(cls):
+    """A numpy-backed MeshGeometry instance must round-trip through pickle
+    with `_xp` restored to the numpy module."""
+    mg = cls.__new__(cls)
+    mg._use_jax = False
+
+    restored = pickle.loads(pickle.dumps(mg))
+
+    assert restored._use_jax is False
+    assert restored._xp is np
+
+
+@pytest.mark.skipif(not _jax_installed(), reason="jax not installed")
+@pytest.mark.parametrize("cls", [MeshGeometryRectangular, MeshGeometryDelaunay])
+def test_pickle_round_trip_jax_backend(cls):
+    """A JAX-backed MeshGeometry instance must round-trip through pickle
+    with `_xp` restored to the jax.numpy module."""
+    import jax.numpy as jnp
+
+    mg = cls.__new__(cls)
+    mg._use_jax = True
+
+    restored = pickle.loads(pickle.dumps(mg))
+
+    assert restored._use_jax is True
+    assert restored._xp is jnp
+
+
+def test_use_jax_inferred_from_xp_kwarg_in_init():
+    """The __init__ continues to accept an `xp=` kwarg but stores it as
+    a boolean — modules never land on the instance."""
+    import types
+
+    # Use __new__ + manual __init__ call with stubbed positional args to
+    # avoid pulling in Mesh / Grid construction. The invariant under test
+    # is post-__init__ state.
+    mg = MeshGeometryRectangular.__new__(MeshGeometryRectangular)
+    MeshGeometryRectangular.__init__(
+        mg,
+        mesh=None,
+        mesh_grid=None,
+        data_grid=None,
+        xp=np,
+    )
+    assert mg._use_jax is False
+    # No module attribute should exist on the instance.
+    module_attrs = [
+        name for name, val in vars(mg).items() if isinstance(val, types.ModuleType)
+    ]
+    assert module_attrs == [], f"unexpected module attrs on instance: {module_attrs}"


### PR DESCRIPTION
## Summary
Phase 4 subprocess visualization (PyAutoFit #1279) requires sending `FitImaging` instances over an IPC boundary. A spike against the current `FitImaging` showed it's unpicklable: `AbstractMeshGeometry.__init__` stores `self._xp = xp` (the literal `numpy` or `jax.numpy` module) and Python can't pickle modules. This was the **only** pickle barrier — the rest of the fit graph (mappers, linear operators, computed matrices, tracer, dataset, mask) serialises fine.

Fix: replace the module-attribute pattern with the `_use_jax: bool` + `_xp` property pattern already used in `Analysis._xp` (PyAutoFit) and `AbstractMaker._xp` (PyAutoArray decorators, per `CLAUDE.md`). Eliminates the pickle barrier at the API level instead of working around it with `__getstate__`/`__setstate__` hooks.

## API Changes
- `AbstractMeshGeometry.__init__(xp=np)` continues to accept the same `xp=` kwarg — no caller changes needed.
- The instance no longer holds `_xp` as a module attribute; it holds `_use_jax: bool` and exposes `_xp` as a `@property` that returns `numpy` or `jax.numpy` on demand.
- All existing `self._xp` reads continue to work transparently (property has the same interface as attribute access).

See full details below.

## Test Plan
- [x] New `test_autoarray/inversion/pixelization/mesh_geometry/test_picklability.py` — 5 new tests covering numpy + JAX backends across `MeshGeometryRectangular` and `MeshGeometryDelaunay`, plus a `__init__`-state invariant test.
- [x] Existing `test_autoarray/inversion/pixelization/mesh_geometry/` tests still pass.
- [x] Wider `test_autoarray/inversion/` suite passes (171/171).
- [x] End-to-end: a populated `FitImaging` (Sersic lens + Rectangular-adaptive-density pixelization source) round-trips through `pickle.dumps/loads` with `log_likelihood` Δ=0.00e+00 on both numpy and JAX backends. Pickle size 4637.7 KB.

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Changed Behaviour
- `autoarray.inversion.mesh.mesh_geometry.abstract.AbstractMeshGeometry`:
  - Instance attribute `_xp` removed; replaced by `_use_jax: bool` (set from the `xp=` kwarg as `xp is not np`).
  - `_xp` is now a `@property` that returns `numpy` if `_use_jax is False` else `jax.numpy`. JAX is imported lazily on access.

### Migration
- No required migration. The `xp=` kwarg on `__init__` is unchanged. Any reader of `instance._xp` continues to work (property returns the same module the old attribute held).
- Any writer of `instance._xp = ...` (none currently exist in the codebase) would now fail at runtime. Confirmed via grep: zero writes outside `__init__`.

### Why this matters
- `FitImaging` now pickles cleanly, unblocking PyAutoFit #1279 (Phase 4 subprocess visualization). The single-class fix on the abstract parent covers both `MeshGeometryRectangular` and `MeshGeometryDelaunay`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)