### PR TITLE
feat: add zoom_extent_scale to Mapper.extent_from for Mid Zoom panel

### DIFF
--- a/autoarray/inversion/mappers/abstract.py
+++ b/autoarray/inversion/mappers/abstract.py
@@ -500,6 +500,7 @@ class Mapper(LinearObj):
         values: np.ndarray = None,
         zoom_to_brightest: bool = True,
         zoom_percent: Optional[float] = None,
+        zoom_extent_scale: float = 1.0,
     ) -> Tuple[float, float, float, float]:
 
         from autoarray.geometry import geometry_util
@@ -516,7 +517,7 @@ class Mapper(LinearObj):
             true_grid = self.source_plane_mesh_grid[true_indices]
 
             try:
-                return geometry_util.extent_symmetric_from(
+                extent = geometry_util.extent_symmetric_from(
                     extent=(
                         np.min(true_grid[:, 0, 1]),
                         np.max(true_grid[:, 0, 1]),
@@ -525,9 +526,38 @@ class Mapper(LinearObj):
                     )
                 )
             except ValueError:
-                return geometry_util.extent_symmetric_from(
+                extent = geometry_util.extent_symmetric_from(
                     extent=self.source_plane_mesh_grid.geometry.extent
                 )
+
+            if zoom_extent_scale != 1.0:
+                x_min, x_max, y_min, y_max = extent
+                x_centre = 0.5 * (x_min + x_max)
+                y_centre = 0.5 * (y_min + y_max)
+                target_half = 0.5 * max(x_max - x_min, y_max - y_min) * zoom_extent_scale
+
+                bound = geometry_util.extent_symmetric_from(
+                    extent=self.source_plane_mesh_grid.geometry.extent
+                )
+                max_allowable_half = min(
+                    x_centre - bound[0],
+                    bound[1] - x_centre,
+                    y_centre - bound[2],
+                    bound[3] - y_centre,
+                )
+                bound_cap_half = 0.7 * 0.5 * min(
+                    bound[1] - bound[0], bound[3] - bound[2]
+                )
+                final_half = min(target_half, max_allowable_half, bound_cap_half)
+
+                extent = (
+                    x_centre - final_half,
+                    x_centre + final_half,
+                    y_centre - final_half,
+                    y_centre + final_half,
+                )
+
+            return extent
 
         return geometry_util.extent_symmetric_from(
             extent=self.source_plane_mesh_grid.geometry.extent

--- a/autoarray/inversion/plot/mapper_plots.py
+++ b/autoarray/inversion/plot/mapper_plots.py
@@ -24,6 +24,7 @@ def plot_mapper(
     line_colors=None,
     title: str = "Pixelization Mesh (Source-Plane)",
     zoom_to_brightest: bool = True,
+    zoom_extent_scale: float = 1.0,
     ax=None,
 ):
     """
@@ -67,6 +68,7 @@ def plot_mapper(
             vmin=vmin,
             vmax=vmax,
             zoom_to_brightest=zoom_to_brightest,
+            zoom_extent_scale=zoom_extent_scale,
             lines=numpy_lines(lines),
             line_colors=line_colors,
             grid=numpy_grid(mesh_grid),

--- a/autoarray/plot/inversion.py
+++ b/autoarray/plot/inversion.py
@@ -25,6 +25,7 @@ def plot_inversion_reconstruction(
     vmax: Optional[float] = None,
     use_log10: bool = False,
     zoom_to_brightest: bool = True,
+    zoom_extent_scale: float = 1.0,
     # --- overlays ---------------------------------------------------------------
     lines: Optional[List[np.ndarray]] = None,
     line_colors: Optional[List] = None,
@@ -106,7 +107,9 @@ def plot_inversion_reconstruction(
         norm = None
 
     extent = mapper.extent_from(
-        values=pixel_values, zoom_to_brightest=zoom_to_brightest
+        values=pixel_values,
+        zoom_to_brightest=zoom_to_brightest,
+        zoom_extent_scale=zoom_extent_scale,
     )
 
     is_subplot = not owns_figure

--- a/test_autoarray/inversion/plot/test_mapper_plotters.py
+++ b/test_autoarray/inversion/plot/test_mapper_plotters.py
@@ -28,6 +28,22 @@ def test__plot_mapper(
     assert str(Path(plot_path) / "mapper1.png") in plot_patch.paths
 
 
+def test__plot_mapper__zoom_extent_scale__widens_extent_around_centre(
+    rectangular_mapper_7x7_3x3,
+    plot_path,
+    plot_patch,
+):
+    aplt.plot_mapper(
+        mapper=rectangular_mapper_7x7_3x3,
+        zoom_extent_scale=2.5,
+        output_path=plot_path,
+        output_filename="mapper_mid_zoom",
+        output_format="png",
+    )
+
+    assert str(Path(plot_path) / "mapper_mid_zoom.png") in plot_patch.paths
+
+
 def test__subplot_image_and_mapper(
     imaging_7x7,
     rectangular_mapper_7x7_3x3,


### PR DESCRIPTION
## Summary
Adds a `zoom_extent_scale` parameter to `Mapper.extent_from` and threads it through `plot_inversion_reconstruction` and `plot_mapper`. This lets callers (notably PyAutoLens's new "Source Plane (Mid Zoom)" subplot panel) request a source-plane view that's a multiple of the brightest-region extent, kept square and clamped so it never exceeds the source-plane mesh extent or sits arbitrarily close to it.

## API Changes
- `Mapper.extent_from(...)` gains an optional `zoom_extent_scale: float = 1.0` argument. Default behaviour is unchanged.
- `plot_inversion_reconstruction(...)` and `plot_mapper(...)` gain the same passthrough kwarg.
- When `zoom_extent_scale > 1.0`, the returned extent is the brightest-region extent expanded by that factor about its centre, capped uniformly so (a) no edge exceeds the source-plane mesh extent (b) the half-width never exceeds 0.7 × the mesh half-width, keeping the panel a strict subset of the No Zoom view.

See full details below.

## Test Plan
- [x] `python -m pytest test_autoarray/inversion/plot test_autoarray/inversion -x` passes
- [x] New `test__plot_mapper__zoom_extent_scale__widens_extent_around_centre` exercises the new kwarg

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `Mapper.extent_from(values=None, zoom_to_brightest=True, zoom_percent=None, zoom_extent_scale=1.0)` — new optional kwarg. Scales the brightness-derived extent by this factor about its centre, clamped to the mesh extent.
- `plot_inversion_reconstruction(..., zoom_extent_scale=1.0, ...)` — new optional kwarg, forwarded to `mapper.extent_from`.
- `plot_mapper(..., zoom_extent_scale=1.0, ...)` — new optional kwarg, forwarded to `plot_inversion_reconstruction`.

### Changed Behaviour
- None when `zoom_extent_scale=1.0` (the default).
- When `zoom_extent_scale != 1.0`, the returned extent is the brightest-region extent scaled by that factor about its centre, then capped to a half-width that is the smallest of: target half-width, distance from brightest centre to the nearest mesh edge, and 0.7 × the mesh half-width.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)