### PR TITLE
fix(mask): cap radius under PYAUTO_SMALL_DATASETS

### DIFF
--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -364,6 +364,14 @@ class Mask2D(Mask):
             if shape_native[0] > 15 or shape_native[1] > 15:
                 shape_native = (15, 15)
                 pixel_scales = 0.6
+            scale_scalar = (
+                pixel_scales
+                if isinstance(pixel_scales, (int, float))
+                else min(pixel_scales)
+            )
+            max_radius = min(shape_native) * scale_scalar / 2.0
+            if radius > max_radius:
+                radius = max_radius
 
         pixel_scales = geometry_util.convert_pixel_scales_2d(pixel_scales=pixel_scales)
 

--- a/test_autoarray/mask/test_mask_2d.py
+++ b/test_autoarray/mask/test_mask_2d.py
@@ -129,6 +129,42 @@ def test__circular__invert_true__output_is_inverted_util_result():
     assert mask.mask_centre == (0.0, 0.0)
 
 
+def test__circular__small_datasets_env__oversized_radius_clamped_to_disc(monkeypatch):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    mask = aa.Mask2D.circular(shape_native=(100, 100), pixel_scales=0.1, radius=6.0)
+
+    assert mask.shape_native == (15, 15)
+    assert mask.pixel_scales == (0.6, 0.6)
+    assert mask.is_circular
+    n_unmasked = int((~mask.array).sum())
+    assert 100 < n_unmasked < 225
+
+
+def test__circular__small_datasets_env__in_bounds_radius_unchanged(monkeypatch):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    capped = aa.Mask2D.circular(shape_native=(15, 15), pixel_scales=0.6, radius=2.0)
+    reference = aa.util.mask_2d.mask_2d_circular_from(
+        shape_native=(15, 15), pixel_scales=(0.6, 0.6), radius=2.0, centre=(0.0, 0.0)
+    )
+
+    assert (capped == reference).all()
+
+
+def test__circular__small_datasets_env__tuple_pixel_scales_oversized_radius_clamped(
+    monkeypatch,
+):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    mask = aa.Mask2D.circular(
+        shape_native=(200, 200), pixel_scales=(0.1, 0.1), radius=7.5
+    )
+
+    assert mask.shape_native == (15, 15)
+    assert mask.is_circular
+
+
 # ---------------------------------------------------------------------------
 # circular_annular
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When `PYAUTO_SMALL_DATASETS=1`, `Mask2D.circular` clamped `shape_native` to `(15, 15)` and `pixel_scales` to `0.6` but left `radius` untouched. Callers asking for `radius` larger than the post-clamp grid half-extent silently received a fully-unmasked 15×15 square instead of a circular disc.

After `cef28716` tightened `is_circular`, this surfaced as a `PixelizationException` from Hilbert image-mesh in two group SLaM scripts (`group/features/{linear_light_profiles,no_lens_light}/slam.py`). The cluster's prescribed root cause ("scripts pass a non-circular mask") was misleading — both scripts already use `Mask2D.circular`; the fault was in the small-datasets shim.

## API Changes

None — internal behaviour change only. Under `PYAUTO_SMALL_DATASETS=1`, `Mask2D.circular` now also clamps `radius` to `min(shape_native) * pixel_scales / 2.0`. Outside that env var the function is unchanged.

See full details below.

## Test Plan

- [x] `pytest test_autoarray/mask/test_mask_2d.py` — 59 passed (3 new tests)
- [x] `PYAUTO_SMALL_DATASETS=1 PYAUTO_TEST_MODE=2 ... python scripts/group/features/no_lens_light/slam.py` — completes 4 searches end-to-end (was raising `PixelizationException`)
- [x] `PYAUTO_SMALL_DATASETS=1 PYAUTO_TEST_MODE=2 ... python scripts/group/features/linear_light_profiles/slam.py` — completes 6 searches end-to-end (was raising `PixelizationException`)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `Mask2D.circular(shape_native, pixel_scales, radius, ...)` — when `PYAUTO_SMALL_DATASETS=1`, `radius` is now clamped to `min(shape_native) * pixel_scales / 2.0`. No effect outside the env var; no effect when `radius` already fits.

### Not Changed
- `Mask2D.circular_annular`, `Mask2D.elliptical`, `Mask2D.elliptical_annular` carry the same latent overflow pattern but are untouched here — no failing cluster exercises them. Same fix can be applied if/when needed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)