### PR TITLE
feat(grids): add respect_small_datasets kwarg to Grid2D.uniform

### DIFF
--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -475,6 +475,7 @@ class Grid2D(Structure):
         pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         over_sample_size: Union[int, Array2D] = 4,
+        respect_small_datasets: bool = True,
     ) -> "Grid2D":
         """
         Create a `Grid2D` (see *Grid2D.__new__*) as a uniform grid of (y,x) values given an input `shape_native` and
@@ -489,8 +490,13 @@ class Grid2D(Structure):
             it is converted to a (float, float) tuple.
         origin
             The origin of the grid's mask.
+        respect_small_datasets
+            When ``PYAUTO_SMALL_DATASETS=1`` is set, grids larger than 15x15 are silently shrunk to
+            ``(15, 15)`` at ``pixel_scales=0.6`` to keep smoke runs fast. Pass ``False`` to opt out
+            of that shrink for grids whose spatial extent is load-bearing for the script (e.g. a
+            visualization asserting cluster-scale critical curves at ~30-50").
         """
-        if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
+        if respect_small_datasets and os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
             if shape_native[0] > 15 or shape_native[1] > 15:
                 shape_native = (15, 15)
                 pixel_scales = 0.6

--- a/test_autoarray/structures/grids/test_uniform_2d.py
+++ b/test_autoarray/structures/grids/test_uniform_2d.py
@@ -176,6 +176,19 @@ def test__uniform__2x2_pixel_scale_2__native_coordinates_correct():
     assert grid_2d.origin == (0.0, 0.0)
 
 
+def test__uniform__small_datasets_env__respect_flag_false__shape_unchanged(monkeypatch):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    grid_2d = aa.Grid2D.uniform(
+        shape_native=(200, 200),
+        pixel_scales=0.5,
+        respect_small_datasets=False,
+    )
+
+    assert grid_2d.shape_native == (200, 200)
+    assert grid_2d.pixel_scales == (0.5, 0.5)
+
+
 def test__uniform__2x2_with_origin__coordinates_offset_by_origin():
     grid_2d = aa.Grid2D.uniform(
         shape_native=(2, 2), pixel_scales=2.0, origin=(1.0, 1.0)


### PR DESCRIPTION
## Summary
Adds `respect_small_datasets: bool = True` kwarg to `Grid2D.uniform`. When `PYAUTO_SMALL_DATASETS=1` is active, the existing logic silently rewrites any shape larger than 15x15 to `(15, 15)` at `pixel_scales=0.6`. Passing `respect_small_datasets=False` opts out of that shrink for the call.

Motivation: a downstream PyAutoGalaxy fix (and an autolens_workspace_test cluster visualization assertion) needs to keep a 100"x100" grid extent in smoke mode to detect a cluster-scale tangential critical curve. The existing shrink defeats every such assertion without changing any of the physics the assertion is meant to detect.

Default behaviour is unchanged — only the explicit opt-out is new.

## API Changes
Adds one optional kwarg `respect_small_datasets: bool = True` to `aa.Grid2D.uniform`. No removed or renamed symbols; existing callers continue to work without change.
See full details below.

## Test Plan
- [x] `pytest test_autoarray/structures/grids/test_uniform_2d.py` — all tests pass including the new `test__uniform__small_datasets_env__respect_flag_false__shape_unchanged`.
- [x] Manual end-to-end: cluster visualization in `autolens_workspace_test` under `PYAUTO_SMALL_DATASETS=1` recovers the expected critical curve (combined with downstream PyAutoGalaxy fix).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `Grid2D.uniform(..., respect_small_datasets: bool = True)` — opt-out flag for the `PYAUTO_SMALL_DATASETS=1` shape-shrink. Default preserves existing behaviour.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)