### PR TITLE
feat: SimulatorImaging(use_jax=True) + xp-aware preprocess noise

### DIFF
--- a/autoarray/dataset/imaging/simulator.py
+++ b/autoarray/dataset/imaging/simulator.py
@@ -26,6 +26,7 @@ class SimulatorImaging:
         include_poisson_noise_in_noise_map: bool = True,
         noise_if_add_noise_false: float = 0.1,
         noise_seed: int = -1,
+        use_jax: bool = False,
     ):
         """
         Simulates observations of `Imaging` data, including simulating the image, noise, blurring due to the telescope
@@ -88,6 +89,20 @@ class SimulatorImaging:
             the value of noise assigned to every pixel in the noise-map.
         noise_seed
             The random seed used to add random noise, where -1 corresponds to a random seed every run.
+        use_jax
+            If ``True``, ``via_image_from`` defaults ``xp`` to ``jax.numpy`` and the
+            simulator's internal noise generation routes through ``jax.random``.
+            The returned ``Imaging`` carries ``jax.Array`` data — useful for
+            JAX-eager batched simulation (parameter sweeps, mock-data studies).
+            Defaults to ``False``.
+
+            Note: ``@jax.jit`` wrapping of ``via_tracer_from`` /
+            ``via_galaxies_from`` is currently blocked by an unrelated
+            pre-existing limitation — ``Array2D.native`` is not jit-traceable
+            because it goes through indexed assignment in
+            ``array_2d_via_indexes_from``. A separate PyAutoArray task is
+            needed to refactor the slim/native reshape to be jit-friendly.
+            Eager JAX usage works today.
         """
 
         if psf is not None:
@@ -105,12 +120,24 @@ class SimulatorImaging:
         self.include_poisson_noise_in_noise_map = include_poisson_noise_in_noise_map
         self.noise_if_add_noise_false = noise_if_add_noise_false
         self.noise_seed = noise_seed
+        self.use_jax = use_jax
+
+    @property
+    def _xp(self):
+        """The array module the simulator runs against by default. ``jnp`` when
+        ``use_jax=True``, ``np`` otherwise. ``via_image_from`` falls back to this
+        when the caller does not pass ``xp=`` explicitly."""
+        if self.use_jax:
+            import jax.numpy as jnp
+
+            return jnp
+        return np
 
     def via_image_from(
         self,
         image: Array2D,
         over_sample_size: Optional[Union[int, np.ndarray]] = None,
-        xp=np,
+        xp=None,
     ) -> Imaging:
         """
         Simulate an `Imaging` dataset from an input image.
@@ -127,13 +154,17 @@ class SimulatorImaging:
             If provided, the returned dataset has its over-sampling updated via `apply_over_sampling`.
             Should be an `Array2D` of integer sub-grid sizes with the same shape as the image.
         xp
-            The array module to use for PSF convolution (default `np` for NumPy, or `jnp` for JAX).
+            The array module to use for PSF convolution. When ``None`` (the default),
+            falls back to ``self._xp`` — which is ``jnp`` if the simulator was constructed
+            with ``use_jax=True`` and ``np`` otherwise. Pass explicitly to override.
 
         Returns
         -------
         Imaging
             The simulated imaging dataset with PSF convolution, noise and background sky applied.
         """
+        if xp is None:
+            xp = self._xp
 
         exposure_time_map = Array2D.full(
             fill_value=self.exposure_time,
@@ -164,6 +195,7 @@ class SimulatorImaging:
             data_eps=image,
             exposure_time_map=exposure_time_map,
             seed=self.noise_seed,
+            xp=xp,
         )
 
         if self.add_poisson_noise_to_data:
@@ -181,7 +213,11 @@ class SimulatorImaging:
                 pixel_scales=image.pixel_scales,
             )
 
-        if np.isnan(noise_map.array).any():
+        # NaN-noise guard is a NumPy-side runtime check (Python `if` on a JAX
+        # tracer triggers TracerBoolConversionError). Under JAX it is the user's
+        # responsibility to confirm exposure_time / background_sky_level are
+        # large enough — JAX silently propagates NaN through the trace.
+        if xp is np and np.isnan(noise_map.array).any():
             raise exc.DatasetException(
                 "The noise-map has NaN values in it. This suggests your exposure time and / or"
                 "background sky levels are too low, creating signal counts at or close to 0.0."
@@ -196,7 +232,16 @@ class SimulatorImaging:
             origin=image.origin,
         )
 
-        image = Array2D(values=image.native, mask=mask)
+        # Re-wrap the image against the all-false mask. Use ``.array`` rather
+        # than ``.native`` on the JAX path: ``.native`` routes through
+        # ``array_2d_via_indexes_from`` which is not jit-safe (it builds a
+        # native-shape array by Python-iterating an index tuple). ``.array``
+        # returns the raw backing array which the ``Array2D`` constructor
+        # accepts in either slim or native shape.
+        if xp is np:
+            image = Array2D(values=image.native, mask=mask)
+        else:
+            image = Array2D(values=image.array, mask=mask)
 
         dataset = Imaging(
             data=image,

--- a/autoarray/dataset/preprocess.py
+++ b/autoarray/dataset/preprocess.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 
 from autoarray import exc
@@ -450,7 +452,7 @@ def setup_random_seed(seed):
     np.random.seed(seed)
 
 
-def poisson_noise_via_data_eps_from(data_eps, exposure_time_map, seed=-1):
+def poisson_noise_via_data_eps_from(data_eps, exposure_time_map, seed=-1, xp=np):
     """
     Generate a two-dimensional poisson noise_maps-mappers from an image.
 
@@ -464,23 +466,38 @@ def poisson_noise_via_data_eps_from(data_eps, exposure_time_map, seed=-1):
         2D array of the exposure time in each pixel used to convert to / from counts and electrons per second.
     seed
         The seed of the random number generator, used for the random noise_maps maps.
+    xp
+        The array module (``numpy`` or ``jax.numpy``). On the JAX path the seed is
+        used to construct a ``jax.random.PRNGKey``; ``seed=-1`` (random per call)
+        falls back to a time-derived 32-bit integer key so the JAX draw is fresh
+        each invocation just like the NumPy path.
 
     Returns
     -------
-    poisson_noise_map: np.ndarray
-        An array describing simulated poisson noise_maps
+    poisson_noise_map
+        An array describing simulated poisson noise_maps. NumPy-backed on the NumPy
+        path, ``jax.Array``-backed on the JAX path.
     """
-    setup_random_seed(seed)
-
     image_counts = data_eps.array * exposure_time_map.array
-    noisy_eps_array = (
-        np.random.poisson(image_counts, data_eps.shape) / exposure_time_map.array
-    )
+
+    if xp is np:
+        setup_random_seed(seed)
+        noisy_eps_array = (
+            np.random.poisson(image_counts, data_eps.shape) / exposure_time_map.array
+        )
+    else:
+        import jax.random
+
+        effective_seed = seed if seed != -1 else int(time.time() * 1e6) & 0xFFFFFFFF
+        key = jax.random.PRNGKey(effective_seed)
+        noisy_eps_array = (
+            jax.random.poisson(key, image_counts) / exposure_time_map.array
+        )
 
     return data_eps.with_new_array(noisy_eps_array) - data_eps
 
 
-def data_eps_with_poisson_noise_added(data_eps, exposure_time_map, seed=-1):
+def data_eps_with_poisson_noise_added(data_eps, exposure_time_map, seed=-1, xp=np):
     """
     Generate a two-dimensional poisson noise_maps-mappers from an image.
 
@@ -494,14 +511,17 @@ def data_eps_with_poisson_noise_added(data_eps, exposure_time_map, seed=-1):
         2D array of the exposure time in each pixel used to convert to / from counts and electrons per second.
     seed
         The seed of the random number generator, used for the random noise_maps maps.
+    xp
+        The array module (``numpy`` or ``jax.numpy``). Threaded through to
+        ``poisson_noise_via_data_eps_from`` to pick the matching RNG.
 
     Returns
     -------
-    poisson_noise_map: np.ndarray
-        An array describing simulated poisson noise_maps
+    poisson_noise_map
+        An array describing simulated poisson noise_maps.
     """
     return data_eps + poisson_noise_via_data_eps_from(
-        data_eps=data_eps, exposure_time_map=exposure_time_map, seed=seed
+        data_eps=data_eps, exposure_time_map=exposure_time_map, seed=seed, xp=xp
     )
 
 

--- a/test_autoarray/dataset/imaging/test_simulator_use_jax.py
+++ b/test_autoarray/dataset/imaging/test_simulator_use_jax.py
@@ -1,0 +1,42 @@
+"""Unit tests for ``SimulatorImaging(use_jax=True)`` constructor wiring.
+
+Per the PyAutoArray dependency-graph rule, library unit tests stay NumPy-only —
+cross-xp numerical parity for the JAX execution path lives in
+``autolens_workspace_test/scripts/imaging/simulator_use_jax_parity.py``.
+"""
+import numpy as np
+
+import autoarray as aa
+
+
+def test_use_jax_defaults_false():
+    simulator = aa.SimulatorImaging(exposure_time=300.0)
+    assert simulator.use_jax is False
+    assert simulator._xp is np
+
+
+def test_use_jax_true_flag_stored():
+    simulator = aa.SimulatorImaging(exposure_time=300.0, use_jax=True)
+    assert simulator.use_jax is True
+
+
+def test_via_image_from_default_xp_falls_back_to_self_xp():
+    """When xp is not passed, via_image_from must fall back to self._xp.
+
+    Construct a no-noise simulator (so the RNG paths don't run) and confirm
+    the call succeeds with the default xp=None resolving to numpy via _xp.
+    """
+    simulator = aa.SimulatorImaging(
+        exposure_time=300.0,
+        add_poisson_noise_to_data=False,
+        include_poisson_noise_in_noise_map=False,
+    )
+
+    image = aa.Array2D.no_mask(
+        values=np.ones((20, 20)),
+        pixel_scales=0.1,
+    )
+
+    dataset = simulator.via_image_from(image=image)
+    assert dataset.data.shape_native == (20, 20)
+    assert isinstance(dataset.data.array, np.ndarray)


### PR DESCRIPTION
## Summary

PR 2 of Phase 2 (`z_features/jax_user_intro.md`). Adds `use_jax=True` to `aa.SimulatorImaging` and routes the Poisson noise pipeline through `jax.random` on the JAX path.

Eager JAX path works (`simulator.via_image_from` with `use_jax=True` returns `Imaging` with `jax.Array` data — useful for batched simulations and parameter sweeps). `@jax.jit` wrapping is currently blocked by an unrelated `Array2D.native` jit-incompatibility in autoarray's slim/native reshape machinery — flagged in the simulator docstring; needs a separate PR.

Companion changes in PyAutoLens (`autolens/imaging/simulator.py`) and PyAutoGalaxy (`autogalaxy/imaging/simulator.py`) — those PRs forward `xp` from the new `_xp` property on the parent.

## API Changes

- **Added:** `aa.SimulatorImaging(..., use_jax=False)` constructor flag.
- **Added:** `aa.SimulatorImaging._xp` property (returns `jnp` if `use_jax`, else `np`).
- **Changed signature:** `aa.SimulatorImaging.via_image_from(xp=None)` — defaults to `self._xp` when `None`.
- **Changed signature:** `preprocess.poisson_noise_via_data_eps_from(..., xp=np)` and `preprocess.data_eps_with_poisson_noise_added(..., xp=np)` gain `xp` parameter; JAX path uses `jax.random.PRNGKey(noise_seed)` + `jax.random.poisson`.
- **Changed behaviour:** the `if xp.isnan(noise_map.array).any():` NaN-guard now only fires on the NumPy path (Python `if` on a JAX tracer triggers `TracerBoolConversionError`).

See full details below.

## Test Plan

- [x] 3 new unit tests in `test_autoarray/dataset/imaging/test_simulator_use_jax.py` — constructor wiring, `_xp` property, `via_image_from(xp=None)` auto-fallback. Numpy-only assertions per `[[feedback_no_jax_in_unit_tests]]`.
- [x] All 831 PyAutoArray tests pass (no regressions to existing `test_simulator.py`).
- [x] Cross-xp parity script at `autolens_workspace_test/scripts/imaging/simulator_use_jax_parity.py` confirms eager NumPy and JAX paths produce identical simulated images to `atol=1e-8` for a noise-free Sersic + Isothermal lens. (Ships with the workspace_test follow-up.)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `aa.SimulatorImaging(use_jax: bool = False)` constructor parameter.
- `aa.SimulatorImaging._xp` property — returns `jax.numpy` if `self.use_jax`, else `numpy`.

### Changed signature
- `aa.SimulatorImaging.via_image_from(image, over_sample_size=None, xp=None)` — `xp` now defaults to `None`, meaning "fall back to `self._xp`". Explicit `xp=np` or `xp=jnp` still honoured.
- `preprocess.poisson_noise_via_data_eps_from(data_eps, exposure_time_map, seed=-1, xp=np)` — new `xp` parameter.
- `preprocess.data_eps_with_poisson_noise_added(data_eps, exposure_time_map, seed=-1, xp=np)` — new `xp` parameter.

### Changed behaviour
- `aa.SimulatorImaging.via_image_from`: the NaN-noise-map runtime guard now only runs on the NumPy path. Under JAX it would trigger `TracerBoolConversionError` because Python `if <tracer>:` is not allowed. JAX users must confirm `exposure_time` / `background_sky_level` are large enough themselves.
- `preprocess.poisson_noise_via_data_eps_from` on the JAX path: uses `jax.random.PRNGKey(seed)` + `jax.random.poisson` instead of `np.random.poisson`. `seed=-1` (random per call) derives a time-based PRNGKey.

### Migration
- No breaking changes. Existing call sites with `xp=np` or no `xp=` continue to work unchanged — `use_jax` defaults to `False`.
- New canonical pattern for JAX-eager simulation:
  ```python
  import autoarray as aa
  simulator = aa.SimulatorImaging(exposure_time=300.0, psf=psf, use_jax=True)
  dataset = simulator.via_image_from(image=my_image)  # Imaging with jax.Array data
  ```

### Known limitations
- `@jax.jit` wrap of `via_image_from` is currently blocked by a pre-existing autoarray limitation: `Array2D.native` routes through `array_2d_via_indexes_from` (indexed assignment of native-index tuples) which is not jit-traceable. Needs a separate slim/native reshape refactor PR.

### Out of scope (separate PRs)
- `aa.SimulatorInterferometer.use_jax=True` + signature symmetry fix (Phase 2 PR 3).
- `xp=np` + jnp-backed-grid mismatch `ValueError` in `AbstractMaker.__init__` (Phase 2 PR 4).
- `Array2D.native` jit-safety refactor (separate task).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)