### PR TITLE
fix: raise ValueError on xp=np + jnp-backed-grid mismatch

### DIFF
--- a/autoarray/structures/decorators/abstract.py
+++ b/autoarray/structures/decorators/abstract.py
@@ -41,6 +41,23 @@ class AbstractMaker:
             Any keyword arguments that are passed to the function when it is evaluated.
         """
 
+        # JAX-pairing-rule guard: if the caller declared xp=np but handed in a
+        # jnp-backed grid, that's almost always a user error inside an
+        # ``@jax.jit`` body — they forgot to pass ``xp=jnp`` to the library
+        # method. The function body would silently host-transfer the tracer
+        # through ``__array__()`` (slow) or fail at the JIT boundary because
+        # the ``if xp is np:`` guard would wrap the result in an ``aa.Array2D``.
+        # Raise here so the user discovers the pairing rule the first time
+        # they break it. See ``admin_jammy/notes/jax_interface.md`` §4.8.
+        if xp is np and getattr(grid, "use_jax", False):
+            raise ValueError(
+                f"Called {getattr(func, '__qualname__', repr(func))} with "
+                f"xp=np but the input grid is JAX-backed (grid.use_jax=True). "
+                f"Inside @jax.jit, pass xp=jnp explicitly to the library call. "
+                f"See the autolens_workspace `scripts/guides/lens_calc.py` "
+                f"`__JAX__` section (Phase 5d) for the JIT-it-yourself pattern."
+            )
+
         self.func = func
         self.obj = obj
         self.grid = grid

--- a/test_autoarray/structures/decorators/test_abstract_xp_mismatch.py
+++ b/test_autoarray/structures/decorators/test_abstract_xp_mismatch.py
@@ -1,0 +1,49 @@
+"""Unit test for the ``AbstractMaker.__init__`` xp/grid mismatch ``ValueError``.
+
+Library unit tests stay NumPy-only per [[feedback_no_jax_in_unit_tests]]. The
+``grid.use_jax`` flag is a plain Python bool on the autoarray side, so we can
+simulate a "JAX-backed grid" with a mock object that has ``use_jax=True``
+without importing JAX.
+"""
+import types
+
+import numpy as np
+import pytest
+
+from autoarray.structures.decorators.abstract import AbstractMaker
+
+
+def _dummy_func(obj, grid, xp):
+    return xp.zeros(1)
+
+
+class _NumpyGrid:
+    use_jax = False
+
+
+class _JaxGrid:
+    use_jax = True
+
+
+def test_raises_on_xp_np_with_jnp_backed_grid():
+    grid = _JaxGrid()
+    with pytest.raises(ValueError) as exc_info:
+        AbstractMaker(func=_dummy_func, obj=None, grid=grid, xp=np)
+    msg = str(exc_info.value)
+    assert "xp=np but the input grid is JAX-backed" in msg
+    assert "_dummy_func" in msg
+
+
+def test_does_not_raise_on_xp_np_with_numpy_grid():
+    grid = _NumpyGrid()
+    maker = AbstractMaker(func=_dummy_func, obj=None, grid=grid, xp=np)
+    assert maker.use_jax is False
+
+
+def test_does_not_raise_on_xp_np_with_grid_lacking_use_jax_attr():
+    """getattr fallback: a grid without ``use_jax`` attribute (e.g. a plain
+    ndarray-like) does not trip the guard — only explicit ``use_jax=True``
+    counts as a mismatch."""
+    grid = types.SimpleNamespace()  # no use_jax attr
+    maker = AbstractMaker(func=_dummy_func, obj=None, grid=grid, xp=np)
+    assert maker.use_jax is False


### PR DESCRIPTION
## Summary

Final PR of Phase 2 of `z_features/jax_user_intro.md`. Adds a clear, loud `ValueError` at `AbstractMaker.__init__` when the caller passes `xp=np` but the input grid is jnp-backed (`grid.use_jax=True`). This is almost always a user error: someone wrote `@jax.jit def f(grid): ...; return some_method(grid)` and forgot to pass `xp=jnp` to `some_method`.

Today's silent failure modes:

- NumPy ops dispatch through `__array__()` on the JAX tracer → host transfer (slow, "works" but secretly wrong).
- The `if xp is np:` guard inside library functions wraps the result in `aa.Array2D`, which then fails at the JIT boundary with a confusing `TypeError: ... is not a valid JAX type`.

With this PR, the guard fires at the function-entry boundary with a clear message pointing at the `lens_calc.py` workspace guide (Phase 5d, where the JIT-it-yourself pattern is canonically documented).

## API Changes

- **Changed behaviour:** `AbstractMaker.__init__` now raises `ValueError` when `xp is np` and `grid.use_jax` is `True`. Pre-existing call sites are unaffected — all of PyAutoArray, PyAutoLens, PyAutoGalaxy continue to pass the tests (verified: 837 / 317 / 918 pass).

See full details below.

## Test Plan

- [x] 3 new unit tests in `test_autoarray/structures/decorators/test_abstract_xp_mismatch.py`:
  - Raises on `xp=np` + jnp-backed grid (with the expected error message format).
  - Does NOT raise on `xp=np` + NumPy grid (preserves existing behaviour).
  - Does NOT raise when the grid has no `use_jax` attribute (e.g. plain ndarray).
- [x] PyAutoArray 837/837 pass.
- [x] PyAutoLens 317/317 pass (no hidden xp/grid mismatch sites in existing code).
- [x] PyAutoGalaxy 918/918 pass.

<details>
<summary>Full API Changes</summary>

### Changed behaviour
- `AbstractMaker.__init__(func, obj, grid, xp=np, *args, **kwargs)` raises `ValueError` at the top of the function when `xp is np` and `getattr(grid, "use_jax", False)` is `True`. Error message includes the called function's qualname and a pointer to the `lens_calc.py` workspace guide.

### Migration
- No breaking changes for code that already passes consistent `xp` and grid types.
- For users who hit the new error: add `xp=jnp` to the library method call inside your `@jax.jit` body, matching the jnp-backed grid you're passing in.

### Future work
- Opt-out kwarg (`_strict_xp=False`) for library internals that legitimately want the host-transfer NumPy fallback path. Not added in this PR because no current site needs it; will add if a real use case surfaces.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)