### PR TITLE
fix: make Array2D.native jit-traceable for JAX simulator path

### DIFF
--- a/autoarray/dataset/imaging/simulator.py
+++ b/autoarray/dataset/imaging/simulator.py
@@ -95,14 +95,6 @@ class SimulatorImaging:
             The returned ``Imaging`` carries ``jax.Array`` data — useful for
             JAX-eager batched simulation (parameter sweeps, mock-data studies).
             Defaults to ``False``.
-
-            Note: ``@jax.jit`` wrapping of ``via_tracer_from`` /
-            ``via_galaxies_from`` is currently blocked by an unrelated
-            pre-existing limitation — ``Array2D.native`` is not jit-traceable
-            because it goes through indexed assignment in
-            ``array_2d_via_indexes_from``. A separate PyAutoArray task is
-            needed to refactor the slim/native reshape to be jit-friendly.
-            Eager JAX usage works today.
         """
 
         if psf is not None:
@@ -232,16 +224,7 @@ class SimulatorImaging:
             origin=image.origin,
         )
 
-        # Re-wrap the image against the all-false mask. Use ``.array`` rather
-        # than ``.native`` on the JAX path: ``.native`` routes through
-        # ``array_2d_via_indexes_from`` which is not jit-safe (it builds a
-        # native-shape array by Python-iterating an index tuple). ``.array``
-        # returns the raw backing array which the ``Array2D`` constructor
-        # accepts in either slim or native shape.
-        if xp is np:
-            image = Array2D(values=image.native, mask=mask)
-        else:
-            image = Array2D(values=image.array, mask=mask)
+        image = Array2D(values=image.native, mask=mask)
 
         dataset = Imaging(
             data=image,

--- a/autoarray/dataset/interferometer/simulator.py
+++ b/autoarray/dataset/interferometer/simulator.py
@@ -64,10 +64,7 @@ class SimulatorInterferometer:
             If ``True``, ``via_image_from`` defaults ``xp`` to ``jax.numpy`` and
             the simulator's internal complex-Gaussian noise generation routes
             through ``jax.random``. The returned ``Interferometer`` carries
-            ``jax.Array`` visibilities. Mirror of ``SimulatorImaging.use_jax``;
-            same caveat applies — ``@jax.jit`` wrapping is currently blocked
-            by autoarray's pre-existing ``.native`` reshape limitation in the
-            transformer / dataset construction path. Eager JAX usage works.
+            ``jax.Array`` visibilities. Mirror of ``SimulatorImaging.use_jax``.
         """
 
         self.uv_wavelengths = uv_wavelengths

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -557,7 +557,10 @@ def array_2d_via_indexes_from(
     array = xp.zeros(shape, dtype=array_2d_slim.dtype)
 
     if xp.__name__.startswith("jax"):
-        array = array.at[tuple(native_index_for_slim_index_2d.T)].set(array_2d_slim)
+        array = array.at[
+            native_index_for_slim_index_2d[:, 0],
+            native_index_for_slim_index_2d[:, 1],
+        ].set(array_2d_slim)
     else:
         array[tuple(native_index_for_slim_index_2d.T)] = array_2d_slim
 


### PR DESCRIPTION
## Summary

`array_2d_via_indexes_from` called `tuple(native_index_for_slim_index_2d.T)` on the JAX path, which iterates the outermost axis of a traced array and triggers `TracerArrayConversionError` under `@jax.jit`. This was the last structural blocker preventing users from wrapping `SimulatorImaging(use_jax=True)` and `SimulatorInterferometer(use_jax=True)` in `@jax.jit`.

Replaced with 2D advanced indexing (`[:, 0], [:, 1]`), removed the temporary `if xp is np` workaround in the imaging simulator, and cleaned up the "jit blocked" docstring caveats on both simulators.

## API Changes

None — internal changes only. `array_2d_via_indexes_from` is a private utility; the simulator public interface is unchanged.

## Test Plan

- [x] All 837 PyAutoArray unit tests pass
- [ ] Workspace parity scripts: `simulator_use_jax_parity.py` (imaging + interferometer) with `@jax.jit` roundtrip enabled (workspace follow-up)
- [ ] Smoke tests on autolens_workspace_test

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour (internal)
- `autoarray.structures.arrays.array_2d_util.array_2d_via_indexes_from` — JAX path now uses 2D advanced indexing instead of `tuple(...T)`. Semantically identical; now jit-traceable.
- `autoarray.dataset.imaging.simulator.SimulatorImaging.via_image_from` — removed the `if xp is np: .native else: .array` guard; always uses `.native` (now safe under JIT).

### Removed (docstring caveats only)
- `SimulatorImaging.__init__` docstring: removed "@jax.jit wrapping is currently blocked" note
- `SimulatorInterferometer.__init__` docstring: removed "@jax.jit wrapping is currently blocked" note

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)