### PR TITLE
fix: VectorYX2DIrregular from_dict round-trip (missing values property)

### DIFF
--- a/autoarray/structures/vectors/irregular.py
+++ b/autoarray/structures/vectors/irregular.py
@@ -55,6 +55,13 @@ class VectorYX2DIrregular(AbstractVectorYX2D):
             self.grid = obj.grid
 
     @property
+    def values(self) -> np.ndarray:
+        """
+        The raw underlying ndarray of (y, x) vector components, with shape [total_vectors, 2].
+        """
+        return self.array
+
+    @property
     def slim(self) -> np.ndarray:
         """
         The vector-field in its 1D representation, an ndarray of shape [total_vectors, 2].

--- a/test_autoarray/structures/vectors/test_vectors_irregular.py
+++ b/test_autoarray/structures/vectors/test_vectors_irregular.py
@@ -96,3 +96,20 @@ def test__vectors_within_radius():
 
     with pytest.raises(exc.VectorYXException):
         vectors.vectors_within_radius(radius=0.0, centre=(0.0, 0.0))
+
+
+def test__json_round_trip(tmp_path):
+    from autoconf.dictable import output_to_json, from_json
+
+    vectors = aa.VectorYX2DIrregular(
+        values=[(0.1, 0.2), (0.3, 0.4)],
+        grid=[(0.0, 0.0), (1.0, 1.0)],
+    )
+
+    file_path = tmp_path / "vectors.json"
+    output_to_json(obj=vectors, file_path=file_path)
+    loaded = from_json(file_path=file_path)
+
+    assert isinstance(loaded, aa.VectorYX2DIrregular)
+    assert np.allclose(loaded.array, vectors.array)
+    assert np.allclose(loaded.grid.array, vectors.grid.array)


### PR DESCRIPTION
## Summary
`al.from_json` failed to load a serialised `WeakDataset` / `ShearYX2DIrregular` because `VectorYX2DIrregular` did not expose its `values` constructor argument as an attribute. `autoconf.dictable.instance_as_dict` consequently emitted a serialized dict containing only `grid`, and `from_dict` then raised `TypeError: VectorYX2DIrregular.__init__() missing 1 required positional argument: 'values'`.

This PR adds a one-line `values` property mirroring the pattern already used by `Grid2DIrregular.values` and `ArrayIrregular.values`. Both `VectorYX2DIrregular` and its `ShearYX2DIrregular` subclass (in PyAutoGalaxy) now round-trip through `output_to_json` / `from_json`.

Refs PyAutoLens issue [#554](https://github.com/PyAutoLabs/PyAutoLens/issues/554).

## API Changes
Added a new public read-only `values` property on `VectorYX2DIrregular` returning the underlying `(N, 2)` ndarray. Purely additive — no existing call sites read `vec.values`. See full details below.

## Test Plan
- [x] New unit test `test__json_round_trip` covers `output_to_json` → `from_json` for `VectorYX2DIrregular`
- [x] Full `test_autoarray/structures/vectors/` and `test_autoarray/structures/grids/` suites pass locally (88 tests)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autoarray.structures.vectors.irregular.VectorYX2DIrregular.values` — property returning the raw `(total_vectors, 2)` ndarray of `[y, x]` components.

### Migration
None — additive only. Existing code that constructed `VectorYX2DIrregular(values=…, grid=…)` is unchanged; the new property simply exposes the stored array under the same `values` name used at construction time.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)