### PR TITLE
Add optional arcsecond double-prime tick labels

### DIFF
--- a/autoarray/config/visualize/general.yaml
+++ b/autoarray/config/visualize/general.yaml
@@ -21,6 +21,7 @@ colormap: autoarray               # Default colormap for 2D plots. Use any matpl
 ticks:
   extent_factor_2d: 0.75  # Fraction of half-extent used for 2D tick positions (< 1.0 pulls ticks inward from edges).
   number_of_ticks_2d: 3   # Number of ticks on each spatial axis of 2D plots.
+  symbol_over_decimal: false  # If true, place the arcsec symbol over the decimal point, e.g. 3."8, instead of after the value, e.g. 3.8".
 contour:
   total_contours: 10       # Number of contour levels drawn over log10 (and explicit linear) plots.
   include_values: true     # Whether to label each contour line with its value.

--- a/autoarray/config/visualize/general.yaml
+++ b/autoarray/config/visualize/general.yaml
@@ -21,7 +21,7 @@ colormap: autoarray               # Default colormap for 2D plots. Use any matpl
 ticks:
   extent_factor_2d: 0.75  # Fraction of half-extent used for 2D tick positions (< 1.0 pulls ticks inward from edges).
   number_of_ticks_2d: 3   # Number of ticks on each spatial axis of 2D plots.
-  symbol_over_decimal: false  # If true, place the arcsec symbol over the decimal point, e.g. 3."8, instead of after the value, e.g. 3.8".
+  symbol_over_decimal: false  # If true, place the arcsec double-prime symbol over the decimal point, e.g. 3.″8, instead of after the value, e.g. 3.8".
 contour:
   total_contours: 10       # Number of contour levels drawn over log10 (and explicit linear) plots.
   include_values: true     # Whether to label each contour line with its value.

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -864,6 +864,14 @@ def _conf_ticks(key: str, default: float) -> float:
         return default
 
 
+def _conf_ticks_flag(key: str, default: bool) -> bool:
+    try:
+        from autoconf import conf
+        return bool(conf.instance["visualize"]["general"]["ticks"][key])
+    except Exception:
+        return default
+
+
 def _inward_ticks(lo: float, hi: float, factor: float, n: int) -> np.ndarray:
     """Return *n* tick positions pulled inward from the extent edges by *factor*."""
     centre = (lo + hi) / 2.0
@@ -895,11 +903,23 @@ def _arcsec_labels(ticks) -> List[str]:
     """Format tick values as arcsecond coordinate strings.
 
     Values that all end in ``.0`` are stripped of the decimal point before the
-    ``"`` suffix is appended, so ``[-1.0, 0.0, 1.0]`` → ``['-1"', '0"', '1"']``.
+    ``"`` suffix is appended, so ``[-1.0, 0.0, 1.0]`` becomes
+    ``['-1"', '0"', '1"']``.  By default decimal labels keep the suffix form
+    ``3.8"``.  When ``ticks.symbol_over_decimal`` is true, decimal labels place
+    the symbol over the decimal point, e.g. ``3."8``.
     """
     labels = [f'{v:g}' for v in ticks]
     if all(label.endswith(".0") for label in labels):
         labels = [label[:-2] for label in labels]
+    if _conf_ticks_flag("symbol_over_decimal", False):
+        symbol_labels = []
+        for label in labels:
+            if "." in label:
+                int_part, frac_part = label.split(".", 1)
+                symbol_labels.append(f'{int_part}."{frac_part}')
+            else:
+                symbol_labels.append(f'{label}"')
+        return symbol_labels
     return [f'{label}"' for label in labels]
 
 

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -905,8 +905,9 @@ def _arcsec_labels(ticks) -> List[str]:
     Values that all end in ``.0`` are stripped of the decimal point before the
     ``"`` suffix is appended, so ``[-1.0, 0.0, 1.0]`` becomes
     ``['-1"', '0"', '1"']``.  By default decimal labels keep the suffix form
-    ``3.8"``.  When ``ticks.symbol_over_decimal`` is true, decimal labels place
-    the symbol over the decimal point, e.g. ``3."8``.
+    ``3.8"``.  When ``ticks.symbol_over_decimal`` is true, labels use the
+    double-prime arcsecond symbol and decimal labels place it over the decimal
+    point, e.g. ``3.″8``.
     """
     labels = [f'{v:g}' for v in ticks]
     if all(label.endswith(".0") for label in labels):
@@ -916,9 +917,9 @@ def _arcsec_labels(ticks) -> List[str]:
         for label in labels:
             if "." in label:
                 int_part, frac_part = label.split(".", 1)
-                symbol_labels.append(f'{int_part}."{frac_part}')
+                symbol_labels.append(f"{int_part}.″{frac_part}")
             else:
-                symbol_labels.append(f'{label}"')
+                symbol_labels.append(f"{label}″")
         return symbol_labels
     return [f'{label}"' for label in labels]
 

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -17,10 +17,10 @@ def test_arcsec_labels_symbol_over_decimal():
         ticks["symbol_over_decimal"] = True
 
         assert _arcsec_labels([-1.69, 0.13, 1.95]) == [
-            '-1."69',
-            '0."13',
-            '1."95',
+            "-1.″69",
+            "0.″13",
+            "1.″95",
         ]
-        assert _arcsec_labels([3.0]) == ['3"']
+        assert _arcsec_labels([3.0]) == ["3″"]
     finally:
         ticks["symbol_over_decimal"] = original

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -1,0 +1,26 @@
+from autoconf import conf
+
+from autoarray.plot.utils import _arcsec_labels
+
+
+def test_arcsec_labels_default_suffix_format():
+    conf.instance["visualize"]["general"]["ticks"]["symbol_over_decimal"] = False
+
+    assert _arcsec_labels([-1.0, 0.0, 1.0]) == ['-1"', '0"', '1"']
+    assert _arcsec_labels([3.8]) == ['3.8"']
+
+
+def test_arcsec_labels_symbol_over_decimal():
+    ticks = conf.instance["visualize"]["general"]["ticks"]
+    original = ticks.get("symbol_over_decimal", False)
+    try:
+        ticks["symbol_over_decimal"] = True
+
+        assert _arcsec_labels([-1.69, 0.13, 1.95]) == [
+            '-1."69',
+            '0."13',
+            '1."95',
+        ]
+        assert _arcsec_labels([3.0]) == ['3"']
+    finally:
+        ticks["symbol_over_decimal"] = original


### PR DESCRIPTION
## Summary
Adds an optional plotting config toggle for arcsecond tick labels that places the arcsecond symbol over the decimal point using the Style Guide double-prime glyph. The default remains off, preserving existing downstream plot labels unless a caller or workspace explicitly opts in.

## API Changes
Adds one optional config key, `visualize.general.ticks.symbol_over_decimal`, defaulting to `false`.
When enabled, 2D arcsecond tick labels use the double-prime symbol over the decimal point, e.g. `3.″8`; when disabled, labels remain unchanged, e.g. `3.8"`.
See full details below.

## Test Plan
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autoarray/plot/test_utils.py test_autoarray/plot/test_output.py`
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autoarray/ -x`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `visualize.general.ticks.symbol_over_decimal` — optional plotting config key, default `false`, for placing arcsecond symbols over decimal points in 2D plot tick labels.

### Changed Behaviour
- `_arcsec_labels(...)` keeps the existing ASCII trailing-quote output when `symbol_over_decimal` is false.
- `_arcsec_labels(...)` emits double-prime arcsecond labels such as `3.″8`, `-1.″69`, and `3″` when `symbol_over_decimal` is true.

### Migration
- Existing users: no change required; the default is unchanged.
- Opt-in users: set `conf.instance["visualize"]["general"]["ticks"]["symbol_over_decimal"] = True` or provide the equivalent config override.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)