### PR TITLE
feat: oversampled PSF convolution core API (convolve_over_sample_size)

### DIFF
--- a/autoarray/dataset/grids.py
+++ b/autoarray/dataset/grids.py
@@ -135,13 +135,17 @@ class GridsDataset:
             self._blurring = None
         else:
 
+            # For an oversampled PSF the blurring mask footprint is defined at
+            # image resolution, and the blurring image must be evaluated on the
+            # fine grid so it can enter the oversampled convolution.
             blurring_mask = self.mask.derive_mask.blurring_from(
-                kernel_shape_native=self.psf.kernel.shape_native, allow_padding=True
+                kernel_shape_native=self.psf.kernel_shape_image_resolution,
+                allow_padding=True,
             )
 
             self._blurring = Grid2D.from_mask(
                 mask=blurring_mask,
-                over_sample_size=1,
+                over_sample_size=self.psf.convolve_over_sample_size,
             )
 
         return self._blurring

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -21,6 +21,57 @@ from autoarray.inversion.inversion.imaging import inversion_imaging_util
 logger = logging.getLogger(__name__)
 
 
+def _validate_convolve_over_sample_size(
+    name: str,
+    convolve_over_sample_size,
+    over_sample_size,
+) -> None:
+    """
+    Validate a `convolve_over_sample_size` input against its matching
+    `over_sample_size`: it must be a plain int >= 1, and when above 1 the matching
+    over sample size must be uniform and equal to it, because the values convolved at
+    the fine resolution must first be evaluated at exactly that resolution (adaptive
+    over sampling makes 2D convolution ill-defined).
+    """
+    if isinstance(convolve_over_sample_size, bool) or not isinstance(
+        convolve_over_sample_size, (int, np.integer)
+    ):
+        raise TypeError(
+            f"convolve_over_sample_size_{name} must be a plain int (adaptive over "
+            f"sampling is not supported for PSF convolution), but a "
+            f"{type(convolve_over_sample_size).__name__} was input."
+        )
+
+    if convolve_over_sample_size < 1:
+        raise exc.DatasetException(
+            f"convolve_over_sample_size_{name} must be >= 1, but "
+            f"{convolve_over_sample_size} was input."
+        )
+
+    if convolve_over_sample_size == 1:
+        return
+
+    if isinstance(over_sample_size, (int, np.integer)) and not isinstance(
+        over_sample_size, bool
+    ):
+        if over_sample_size == convolve_over_sample_size:
+            return
+        raise exc.DatasetException(
+            f"convolve_over_sample_size_{name}={convolve_over_sample_size} requires "
+            f"over_sample_size_{name} to be equal to it, but "
+            f"{over_sample_size} was input. The values convolved at the fine "
+            f"resolution must be evaluated at that same resolution."
+        )
+
+    if not np.all(np.array(over_sample_size) == convolve_over_sample_size):
+        raise exc.DatasetException(
+            f"convolve_over_sample_size_{name}={convolve_over_sample_size} requires "
+            f"a uniform over_sample_size_{name} equal to it, but a non-uniform or "
+            f"unequal array was input. Adaptive over sampling makes 2D PSF "
+            f"convolution ill-defined."
+        )
+
+
 class Imaging(AbstractDataset):
     def __init__(
         self,
@@ -31,6 +82,8 @@ class Imaging(AbstractDataset):
         noise_covariance_matrix: Optional[np.ndarray] = None,
         over_sample_size_lp: Union[int, Array2D] = 4,
         over_sample_size_pixelization: Union[int, Array2D] = 4,
+        convolve_over_sample_size_lp: int = 1,
+        convolve_over_sample_size_pixelization: int = 1,
         use_normalized_psf: Optional[bool] = True,
         check_noise_map: bool = True,
         sparse_operator: Optional[ImagingSparseOperator] = None,
@@ -82,6 +135,17 @@ class Imaging(AbstractDataset):
         over_sample_size_pixelization
             How over sampling is performed for the grid which is associated with a pixelization, which is therefore
             passed into the calculations performed in the `inversion` module.
+        convolve_over_sample_size_lp
+            The over sample size of the PSF for light-profile operations. If above 1, PSF convolution of light
+            profile images is performed at this multiple of the image resolution (requiring the PSF to be supplied
+            at that resolution) and binned back to image resolution, improving the accuracy of the blurring.
+            Requires `over_sample_size_lp` to be uniform and equal to it. A value of 1 (default) leaves all
+            behaviour unchanged.
+        convolve_over_sample_size_pixelization
+            The over sample size of the PSF for pixelization operations, with the same requirements as
+            `convolve_over_sample_size_lp` applied to `over_sample_size_pixelization`. Incompatible with the
+            sparse linear algebra formalism (`sparse_operator`), whose PSF products are precomputed at image
+            resolution.
         use_normalized_psf
             If `True`, the PSF kernel values are rescaled such that they sum to 1.0. This can be important for ensuring
             the PSF kernel does not change the overall normalization of the image when it is convolved with it.
@@ -92,6 +156,45 @@ class Imaging(AbstractDataset):
             noise-map values given the PSF (see `inversion.inversion_util`). Pass the `ImagingSparseOperator` object here to
             enable this linear algebra formalism for pixelized reconstructions.
         """
+
+        _validate_convolve_over_sample_size(
+            name="lp",
+            convolve_over_sample_size=convolve_over_sample_size_lp,
+            over_sample_size=over_sample_size_lp,
+        )
+        _validate_convolve_over_sample_size(
+            name="pixelization",
+            convolve_over_sample_size=convolve_over_sample_size_pixelization,
+            over_sample_size=over_sample_size_pixelization,
+        )
+
+        if (
+            convolve_over_sample_size_lp > 1
+            and convolve_over_sample_size_pixelization > 1
+            and convolve_over_sample_size_lp != convolve_over_sample_size_pixelization
+        ):
+            raise exc.DatasetException(
+                f"Different convolve_over_sample_size values for the lp "
+                f"({convolve_over_sample_size_lp}) and pixelization "
+                f"({convolve_over_sample_size_pixelization}) operations are not yet "
+                f"supported, because the dataset holds a single PSF kernel at one "
+                f"resolution."
+            )
+
+        if (
+            sparse_operator is not None
+            and convolve_over_sample_size_pixelization > 1
+        ):
+            raise exc.DatasetException(
+                "convolve_over_sample_size_pixelization > 1 is incompatible with the "
+                "sparse linear algebra formalism (sparse_operator), whose PSF "
+                "products are precomputed at image resolution."
+            )
+
+        self.convolve_over_sample_size_lp = int(convolve_over_sample_size_lp)
+        self.convolve_over_sample_size_pixelization = int(
+            convolve_over_sample_size_pixelization
+        )
 
         super().__init__(
             data=data,
@@ -115,6 +218,11 @@ class Imaging(AbstractDataset):
                     """
                 )
 
+        convolve_over_sample_size = max(
+            self.convolve_over_sample_size_lp,
+            self.convolve_over_sample_size_pixelization,
+        )
+
         if psf is not None:
 
             if use_normalized_psf:
@@ -123,12 +231,31 @@ class Imaging(AbstractDataset):
                     psf.kernel._array, np.sum(psf.kernel._array)
                 )
 
+            if (
+                convolve_over_sample_size > 1
+                and psf.convolve_over_sample_size != convolve_over_sample_size
+            ):
+                psf = Convolver(
+                    kernel=psf.kernel,
+                    use_fft=psf._use_fft,
+                    convolve_over_sample_size=convolve_over_sample_size,
+                )
+
             if psf_setup_state:
 
-                state = ConvolverState(kernel=psf.kernel, mask=self.data.mask)
+                # Always rebuild for this dataset's mask — state_from would return a
+                # cached state built for a previous mask (e.g. via apply_mask).
+                if psf.convolve_over_sample_size > 1:
+                    state = psf._fine_state_from(mask=self.data.mask)
+                else:
+                    state = ConvolverState(kernel=psf.kernel, mask=self.data.mask)
 
                 psf = Convolver(
-                    kernel=psf.kernel, state=state, normalize=use_normalized_psf
+                    kernel=psf.kernel,
+                    state=state,
+                    normalize=use_normalized_psf,
+                    use_fft=psf._use_fft,
+                    convolve_over_sample_size=psf.convolve_over_sample_size,
                 )
 
         self.psf = psf
@@ -156,6 +283,9 @@ class Imaging(AbstractDataset):
         check_noise_map: bool = True,
         over_sample_size_lp: Union[int, Array2D] = 4,
         over_sample_size_pixelization: Union[int, Array2D] = 4,
+        convolve_over_sample_size_lp: int = 1,
+        convolve_over_sample_size_pixelization: int = 1,
+        psf_pixel_scales: Optional[ty.PixelScales] = None,
     ) -> "Imaging":
         """
         Load an imaging dataset from multiple .fits file.
@@ -201,6 +331,15 @@ class Imaging(AbstractDataset):
         over_sample_size_pixelization
             How over sampling is performed for the grid which is associated with a pixelization, which is therefore
             passed into the calculations performed in the `inversion` module.
+        convolve_over_sample_size_lp
+            The over sample size of the PSF for light-profile operations (see `Imaging.__init__`). If above 1
+            the PSF .fits file must contain the PSF sampled at that multiple of the image resolution, and its
+            pixel scales are set accordingly (or via `psf_pixel_scales`).
+        convolve_over_sample_size_pixelization
+            The over sample size of the PSF for pixelization operations (see `Imaging.__init__`).
+        psf_pixel_scales
+            Optional explicit pixel scales of the PSF .fits file. Defaults to the image pixel scales divided by
+            the convolve over sample size (i.e. the fine resolution when oversampled convolution is used).
         """
 
         from autoarray.util.dataset_util import cap_array_2d_for_small_datasets
@@ -216,13 +355,27 @@ class Imaging(AbstractDataset):
         noise_map, pixel_scales = cap_array_2d_for_small_datasets(noise_map, pixel_scales)
 
         if psf_path is not None:
+
+            convolve_over_sample_size = max(
+                convolve_over_sample_size_lp, convolve_over_sample_size_pixelization
+            )
+
+            if psf_pixel_scales is None:
+                if isinstance(pixel_scales, (int, float)):
+                    psf_pixel_scales = pixel_scales / convolve_over_sample_size
+                else:
+                    psf_pixel_scales = tuple(
+                        ps / convolve_over_sample_size for ps in pixel_scales
+                    )
+
             kernel = Array2D.from_fits(
                 file_path=psf_path,
                 hdu=psf_hdu,
-                pixel_scales=pixel_scales,
+                pixel_scales=psf_pixel_scales,
             )
             psf = Convolver(
                 kernel=kernel,
+                convolve_over_sample_size=convolve_over_sample_size,
             )
 
         else:
@@ -237,6 +390,8 @@ class Imaging(AbstractDataset):
             check_noise_map=check_noise_map,
             over_sample_size_lp=over_sample_size_lp,
             over_sample_size_pixelization=over_sample_size_pixelization,
+            convolve_over_sample_size_lp=convolve_over_sample_size_lp,
+            convolve_over_sample_size_pixelization=convolve_over_sample_size_pixelization,
         )
 
     def apply_mask(self, mask: Mask2D) -> "Imaging":
@@ -303,6 +458,8 @@ class Imaging(AbstractDataset):
             noise_covariance_matrix=noise_covariance_matrix,
             over_sample_size_lp=over_sample_size_lp,
             over_sample_size_pixelization=over_sample_size_pixelization,
+            convolve_over_sample_size_lp=self.convolve_over_sample_size_lp,
+            convolve_over_sample_size_pixelization=self.convolve_over_sample_size_pixelization,
         )
 
         logger.info(
@@ -423,6 +580,8 @@ class Imaging(AbstractDataset):
             over_sample_size_lp=over_sample_size_lp or self.over_sample_size_lp,
             over_sample_size_pixelization=over_sample_size_pixelization
             or self.over_sample_size_pixelization,
+            convolve_over_sample_size_lp=self.convolve_over_sample_size_lp,
+            convolve_over_sample_size_pixelization=self.convolve_over_sample_size_pixelization,
             check_noise_map=False,
         )
 
@@ -455,6 +614,13 @@ class Imaging(AbstractDataset):
             A new `Imaging` dataset with the precomputed `ImagingSparseOperator` attached, enabling
             efficient pixelized source reconstruction via the sparse linear algebra formalism.
         """
+
+        if self.psf is not None and self.psf.convolve_over_sample_size > 1:
+            raise exc.DatasetException(
+                "The sparse linear algebra formalism precomputes PSF products at "
+                "image resolution and is incompatible with an oversampled PSF "
+                "(convolve_over_sample_size > 1)."
+            )
 
         logger.info(
             "IMAGING - Setting Up Sparse Operator For low Memory Pixelizations."

--- a/autoarray/operators/convolver.py
+++ b/autoarray/operators/convolver.py
@@ -22,6 +22,7 @@ class ConvolverState:
         self,
         kernel: Array2D,
         mask: Mask2D,
+        blurring_mask: Optional["Mask2D"] = None,
     ):
         """
         Compute and store the padded shapes and masks required for FFT-based convolution
@@ -80,6 +81,12 @@ class ConvolverState:
             A 2D boolean mask where False values indicate unmasked (valid) pixels and
             True values indicate masked pixels. The spatial extent of False pixels
             defines the region of the image that is embedded into FFT space.
+        blurring_mask
+            Optional explicit blurring mask (same shape as ``mask``, before FFT
+            resizing). If omitted it is derived from the resized mask and kernel shape
+            as before. Oversampled convolution passes the upscaled image-resolution
+            blurring mask here, because the region a caller evaluates blurring flux on
+            is defined at image resolution, not by the fine kernel's reach.
 
         Attributes
         ----------
@@ -118,7 +125,16 @@ class ConvolverState:
         import scipy.fft
         from autoarray.mask.mask_2d_util import required_shape_for_kernel
 
-        min_blur_shape = required_shape_for_kernel(mask, self.kernel.shape_native)
+        if blurring_mask is None:
+            min_blur_shape = required_shape_for_kernel(mask, self.kernel.shape_native)
+        else:
+            # The explicit blurring region can extend further than the kernel's own
+            # reach (its footprint is defined at image resolution and upscaled), so
+            # the FFT frame must be sized to keep every blurring pixel after resizing.
+            combined_mask = np.array(mask) & np.array(blurring_mask)
+            min_blur_shape = required_shape_for_kernel(
+                combined_mask, self.kernel.shape_native
+            )
 
         fft_shape = tuple(
             scipy.fft.next_fast_len(max(s, r), real=True)
@@ -127,9 +143,22 @@ class ConvolverState:
 
         self.fft_shape = fft_shape
         self.mask = mask.resized_from(self.fft_shape, pad_value=1)
-        self.blurring_mask = self.mask.derive_mask.blurring_from(
-            kernel_shape_native=self.kernel.shape_native
-        )
+
+        if blurring_mask is None:
+            self.blurring_mask = self.mask.derive_mask.blurring_from(
+                kernel_shape_native=self.kernel.shape_native
+            )
+        else:
+            self.blurring_mask = blurring_mask.resized_from(
+                self.fft_shape, pad_value=1
+            )
+
+        # Set by Convolver.state_from when convolve_over_sample_size > 1: the
+        # permutations from per-pixel sub-block ordering to the fine mask's
+        # row-major slim ordering, for the image and blurring regions.
+        self.sub_slim_to_fine_slim = None
+        self.blurring_sub_slim_to_fine_slim = None
+        self.image_mask = None
 
         self.fft_kernel = np.fft.rfft2(self.kernel.native.array, s=self.fft_shape)
         self.fft_kernel_mapping = np.expand_dims(self.fft_kernel, 2)
@@ -149,6 +178,7 @@ class Convolver:
         state: Optional[ConvolverState] = None,
         normalize: bool = False,
         use_fft: Optional[bool] = None,
+        convolve_over_sample_size: int = 1,
         *args,
         **kwargs,
     ):
@@ -200,6 +230,16 @@ class Convolver:
             ``ConvolverState``.
             If False, convolution is performed in real space.
             If None, the default behaviour specified in the configuration is used.
+        convolve_over_sample_size
+            The integer over sample size of the PSF. If above 1, the ``kernel`` is the
+            PSF sampled at ``over_sample_size`` times the image resolution (e.g. a
+            value of 2 means the PSF has a resolution 2x higher than the image, with
+            pixel scales half the image's). Convolution is then performed on a grid
+            upscaled by this factor and the result binned back to image resolution by
+            the mean of each block, improving the accuracy of the blurring. The
+            convolution methods then expect over-sampled (sub-gridded) inputs rather
+            than image-resolution arrays. A value of 1 (default) leaves all behaviour
+            unchanged.
         *args, **kwargs
             Passed to the ``Array2D`` constructor.
 
@@ -230,9 +270,49 @@ class Convolver:
             ):
                 raise exc.KernelException("Convolver Convolver must be odd")
 
+        if isinstance(convolve_over_sample_size, bool) or not isinstance(
+            convolve_over_sample_size, (int, np.integer)
+        ):
+            raise TypeError(
+                f"convolve_over_sample_size must be a plain int (adaptive over "
+                f"sampling is not supported for PSF convolution), but a "
+                f"{type(convolve_over_sample_size).__name__} was input."
+            )
+
+        if convolve_over_sample_size < 1:
+            raise exc.KernelException(
+                f"convolve_over_sample_size must be >= 1, but "
+                f"{convolve_over_sample_size} was input."
+            )
+
+        self.convolve_over_sample_size = int(convolve_over_sample_size)
+
         self._state = state
 
+    @property
+    def kernel_shape_image_resolution(self) -> Tuple[int, int]:
+        """
+        The shape of the kernel's footprint in image-resolution pixels.
+
+        For ``convolve_over_sample_size=1`` this is the kernel's native shape. For an
+        oversampled kernel it is the (odd) number of image pixels the fine kernel
+        reaches, used e.g. to derive the image-resolution blurring mask.
+        """
+        s = self.convolve_over_sample_size
+
+        if s == 1:
+            return self.kernel.shape_native
+
+        return tuple(2 * int(np.ceil((k // 2) / s)) + 1 for k in self.kernel.shape_native)
+
     def state_from(self, mask):
+
+        if self.convolve_over_sample_size > 1:
+
+            if self._state is not None:
+                return self._state
+
+            return self._fine_state_from(mask=mask)
 
         if (
             mask.shape_native[0] != self.kernel.shape_native[0]
@@ -244,6 +324,325 @@ class Convolver:
             return ConvolverState(kernel=self.kernel, mask=mask)
 
         return self._state
+
+    def _fine_state_from(self, mask) -> ConvolverState:
+        """
+        Build the ``ConvolverState`` for oversampled convolution: the input
+        image-resolution mask is upscaled by ``convolve_over_sample_size`` and the
+        existing state machinery runs on the fine mask, with the sub-block <-> fine
+        slim permutations cached on the state.
+
+        Parameters
+        ----------
+        mask
+            The image-resolution mask the over-sampled inputs are defined on.
+        """
+        from autoarray.operators.over_sampling.over_sample_util import (
+            mask_2d_upscaled_from,
+            sub_slim_to_fine_slim_from,
+        )
+
+        s = self.convolve_over_sample_size
+
+        expected_pixel_scales = (
+            mask.pixel_scales[0] / s,
+            mask.pixel_scales[1] / s,
+        )
+
+        if not np.allclose(
+            self.kernel.pixel_scales, expected_pixel_scales, rtol=1.0e-4
+        ):
+            raise exc.KernelException(
+                f"The kernel's pixel scales {self.kernel.pixel_scales} do not match "
+                f"the mask's pixel scales divided by convolve_over_sample_size="
+                f"{s} ({expected_pixel_scales}). An oversampled Convolver requires "
+                f"the PSF sampled at the fine resolution."
+            )
+
+        mask_fine = mask_2d_upscaled_from(mask_2d=mask, over_sample_size=s)
+
+        blurring_mask = mask.derive_mask.blurring_from(
+            kernel_shape_native=self.kernel_shape_image_resolution,
+            allow_padding=True,
+        )
+        blurring_mask_fine = mask_2d_upscaled_from(
+            mask_2d=blurring_mask, over_sample_size=s
+        )
+
+        state = ConvolverState(
+            kernel=self.kernel, mask=mask_fine, blurring_mask=blurring_mask_fine
+        )
+
+        state.sub_slim_to_fine_slim = sub_slim_to_fine_slim_from(
+            mask_2d=mask, over_sample_size=s
+        )
+        state.blurring_sub_slim_to_fine_slim = sub_slim_to_fine_slim_from(
+            mask_2d=blurring_mask, over_sample_size=s
+        )
+        state.image_mask = mask
+
+        return state
+
+    def _over_sampled_state_from(self, mask=None) -> ConvolverState:
+        """
+        Resolve the fine ``ConvolverState`` for oversampled convolution: the
+        precomputed state if one was supplied (e.g. via ``Imaging(psf_setup_state=True)``),
+        else built from an explicit image-resolution mask. Over-sampled inputs cannot
+        carry the image mask themselves, so having neither is an error.
+        """
+        if self._state is not None:
+            return self._state
+
+        if mask is not None:
+            return self._fine_state_from(mask=mask)
+
+        raise exc.KernelException(
+            "Oversampled convolution (convolve_over_sample_size > 1) requires either "
+            "a precomputed ConvolverState or an explicit image-resolution mask, "
+            "because over-sampled input arrays do not carry the mask."
+        )
+
+    def _check_over_sampled_length(self, n: int, perm: np.ndarray) -> None:
+        """
+        Validate the length of an over-sampled input against the cached permutation;
+        a binned (image-resolution) input is a distinct, explicit error.
+        """
+        if n == perm.size:
+            return
+
+        s = self.convolve_over_sample_size
+
+        if n * s**2 == perm.size:
+            raise exc.KernelException(
+                f"An image-resolution (binned) array of length {n} was input to an "
+                f"oversampled Convolver (convolve_over_sample_size={s}), which "
+                f"requires the over-sampled values of length {perm.size} in "
+                f"per-pixel sub-block order (evaluate on the over-sampled grid "
+                f"without binning)."
+            )
+
+        raise exc.KernelException(
+            f"The input array length {n} does not match the expected over-sampled "
+            f"length {perm.size} (convolve_over_sample_size="
+            f"{self.convolve_over_sample_size})."
+        )
+
+    def _convolved_image_over_sampled_np_from(self, image, blurring_image, mask=None):
+        """
+        Real-space numpy convolution of over-sampled inputs: scatter the sub-gridded
+        image (and blurring image) onto the fine FFT frame via the cached
+        permutations, convolve with the fine kernel, and bin the result back to
+        image resolution by the mean of each sub-block.
+        """
+        from scipy.signal import convolve as scipy_convolve
+
+        s = self.convolve_over_sample_size
+        state = self._over_sampled_state_from(mask=mask)
+
+        values = image.array if hasattr(image, "array") else np.asarray(image)
+        perm = state.sub_slim_to_fine_slim
+        self._check_over_sampled_length(n=values.shape[0], perm=perm)
+
+        rows, cols = state.mask.slim_to_native_tuple
+
+        image_native = np.zeros(state.fft_shape)
+        image_native[rows[perm], cols[perm]] = values
+
+        if blurring_image is not None:
+            blurring_values = (
+                blurring_image.array
+                if hasattr(blurring_image, "array")
+                else np.asarray(blurring_image)
+            )
+            bperm = state.blurring_sub_slim_to_fine_slim
+            self._check_over_sampled_length(n=blurring_values.shape[0], perm=bperm)
+            brows, bcols = state.blurring_mask.slim_to_native_tuple
+            image_native[brows[bperm], bcols[bperm]] = blurring_values
+        else:
+            warnings.warn(
+                "No blurring_image provided. Only the direct image will be convolved. "
+                "This may change the correctness of the PSF convolution."
+            )
+
+        convolve_native = scipy_convolve(
+            image_native, self.kernel.native.array, mode="same", method="auto"
+        )
+
+        fine_slim = convolve_native[state.mask.slim_to_native_tuple]
+        binned = fine_slim[perm].reshape(-1, s**2).mean(axis=1)
+
+        return Array2D(values=binned, mask=state.image_mask)
+
+    def _convolved_mapping_matrix_over_sampled_np_from(
+        self, mapping_matrix, mask, blurring_mapping_matrix=None
+    ):
+        """
+        Real-space numpy convolution of an over-sampled mapping matrix (one row per
+        sub-pixel, per-pixel sub-block order): scatter each source column onto the
+        fine FFT frame, convolve, and bin rows back to image resolution.
+        """
+        from scipy.signal import convolve as scipy_convolve
+
+        s = self.convolve_over_sample_size
+        state = self._over_sampled_state_from(mask=mask)
+
+        perm = state.sub_slim_to_fine_slim
+        self._check_over_sampled_length(n=mapping_matrix.shape[0], perm=perm)
+
+        n_src = mapping_matrix.shape[1]
+        rows, cols = state.mask.slim_to_native_tuple
+
+        native = np.zeros(state.fft_shape + (n_src,))
+        native[rows[perm], cols[perm], :] = mapping_matrix
+
+        if blurring_mapping_matrix is not None:
+            bperm = state.blurring_sub_slim_to_fine_slim
+            self._check_over_sampled_length(
+                n=blurring_mapping_matrix.shape[0], perm=bperm
+            )
+            brows, bcols = state.blurring_mask.slim_to_native_tuple
+            native[brows[bperm], bcols[bperm], :] = blurring_mapping_matrix
+
+        blurred_native = scipy_convolve(
+            native, self.kernel.native.array[..., None], mode="same"
+        )
+
+        fine_slim = blurred_native[state.mask.slim_to_native_tuple]
+        return fine_slim[perm].reshape(-1, s**2, n_src).mean(axis=1)
+
+    def _convolved_image_over_sampled_jax_from(
+        self, image, blurring_image, mask=None, use_mixed_precision: bool = False, xp=np
+    ):
+        """
+        FFT (JAX) convolution of over-sampled inputs: the body mirrors the s=1 FFT
+        path of ``convolved_image_from`` on the fine-mask state, with the scatter
+        indices permuted from sub-block order and a mean bin-down appended.
+        """
+        import jax
+        import jax.numpy as jnp
+
+        s = self.convolve_over_sample_size
+        state = self._over_sampled_state_from(mask=mask)
+
+        values = image.array if hasattr(image, "array") else image
+        perm = state.sub_slim_to_fine_slim
+        self._check_over_sampled_length(n=values.shape[0], perm=perm)
+
+        real_dtype = jnp.float32 if use_mixed_precision else jnp.float64
+
+        rows, cols = state.mask.slim_to_native_tuple
+
+        image_both_native = xp.zeros(state.fft_shape, dtype=real_dtype)
+        image_both_native = image_both_native.at[rows[perm], cols[perm]].set(
+            jnp.asarray(values, dtype=real_dtype)
+        )
+
+        if blurring_image is not None:
+            blurring_values = (
+                blurring_image.array
+                if hasattr(blurring_image, "array")
+                else blurring_image
+            )
+            bperm = state.blurring_sub_slim_to_fine_slim
+            self._check_over_sampled_length(n=blurring_values.shape[0], perm=bperm)
+            brows, bcols = state.blurring_mask.slim_to_native_tuple
+            image_both_native = image_both_native.at[brows[bperm], bcols[bperm]].set(
+                jnp.asarray(blurring_values, dtype=real_dtype)
+            )
+        else:
+            warnings.warn(
+                "No blurring_image provided. Only the direct image will be convolved. "
+                "This may change the correctness of the PSF convolution."
+            )
+
+        fft_image_native = xp.fft.rfft2(
+            image_both_native, s=state.fft_shape, axes=(0, 1)
+        )
+
+        fft_kernel = state.fft_kernel_c64 if use_mixed_precision else state.fft_kernel
+
+        blurred_image_full = xp.fft.irfft2(
+            fft_kernel * fft_image_native, s=state.fft_shape, axes=(0, 1)
+        )
+        ky, kx = self.kernel.shape_native
+        off_y = (ky - 1) // 2
+        off_x = (kx - 1) // 2
+
+        blurred_image_full = xp.roll(
+            blurred_image_full, shift=(-off_y, -off_x), axis=(0, 1)
+        )
+
+        blurred_image_native = jax.lax.dynamic_slice(
+            blurred_image_full, (off_y, off_x), state.fft_shape
+        )
+
+        fine_slim = blurred_image_native[state.mask.slim_to_native_tuple]
+        binned = fine_slim[perm].reshape(-1, s**2).mean(axis=1)
+
+        return Array2D(values=binned, mask=state.image_mask)
+
+    def _convolved_mapping_matrix_over_sampled_jax_from(
+        self,
+        mapping_matrix,
+        mask,
+        blurring_mapping_matrix=None,
+        use_mixed_precision: bool = False,
+        xp=np,
+    ):
+        """
+        FFT (JAX) convolution of an over-sampled mapping matrix, mirroring the s=1
+        FFT path of ``convolved_mapping_matrix_from`` on the fine-mask state with
+        permuted scatter and a mean bin-down of the rows.
+        """
+        import jax
+        import jax.numpy as jnp
+
+        s = self.convolve_over_sample_size
+        state = self._over_sampled_state_from(mask=mask)
+
+        perm = state.sub_slim_to_fine_slim
+        self._check_over_sampled_length(n=mapping_matrix.shape[0], perm=perm)
+
+        n_src = mapping_matrix.shape[1]
+        dtype_native = jnp.float32 if use_mixed_precision else jnp.float64
+
+        rows, cols = state.mask.slim_to_native_tuple
+
+        native = xp.zeros(state.fft_shape + (n_src,), dtype=dtype_native)
+        native = native.at[rows[perm], cols[perm], :].set(
+            jnp.asarray(mapping_matrix, dtype=dtype_native)
+        )
+
+        if blurring_mapping_matrix is not None:
+            bperm = state.blurring_sub_slim_to_fine_slim
+            self._check_over_sampled_length(
+                n=blurring_mapping_matrix.shape[0], perm=bperm
+            )
+            brows, bcols = state.blurring_mask.slim_to_native_tuple
+            native = native.at[brows[bperm], bcols[bperm], :].set(
+                jnp.asarray(blurring_mapping_matrix, dtype=dtype_native)
+            )
+
+        fft_native = xp.fft.rfft2(native, s=state.fft_shape, axes=(0, 1))
+
+        blurred_full = xp.fft.irfft2(
+            state.fft_kernel_mapping * fft_native, s=state.fft_shape, axes=(0, 1)
+        )
+
+        ky, kx = self.kernel.shape_native
+        off_y = (ky - 1) // 2
+        off_x = (kx - 1) // 2
+
+        blurred_full = xp.roll(blurred_full, shift=(-off_y, -off_x), axis=(0, 1))
+
+        out_shape = state.fft_shape + (n_src,)
+
+        blurred_native = jax.lax.dynamic_slice(
+            blurred_full, (off_y, off_x, 0), out_shape
+        )
+
+        fine_slim = blurred_native[state.mask.slim_to_native_tuple]
+        return fine_slim[perm].reshape(-1, s**2, n_src).mean(axis=1)
 
     @property
     def use_fft(self):
@@ -262,7 +661,12 @@ class Convolver:
         the normalized kernel.
         """
         kernel_copy = self.kernel.copy()
-        return Convolver(kernel=kernel_copy, state=None, normalize=True)
+        return Convolver(
+            kernel=kernel_copy,
+            state=None,
+            normalize=True,
+            convolve_over_sample_size=self.convolve_over_sample_size,
+        )
 
     @classmethod
     def no_blur(cls, pixel_scales):
@@ -480,6 +884,7 @@ class Convolver:
         blurring_image,
         jax_method="direct",
         use_mixed_precision: bool = False,
+        mask: Optional["Mask2D"] = None,
         xp=np,
     ):
         """
@@ -517,12 +922,36 @@ class Convolver:
         jax_method : {"direct", "fft"}
             Backend passed to ``jax.scipy.signal.convolve`` when in real-space mode.
             Ignored for FFT convolutions.
+        mask
+            The image-resolution mask, required when ``convolve_over_sample_size > 1``
+            and no precomputed state exists, because over-sampled inputs do not carry
+            the mask. Ignored otherwise.
 
         Returns
         -------
         Array2D
             The convolved image in slim (1D masked) format.
+
+        Notes
+        -----
+        When ``convolve_over_sample_size > 1`` the ``image`` and ``blurring_image``
+        must be the over-sampled (sub-gridded, per-pixel sub-block ordered) values —
+        evaluate on the over-sampled grid without binning. The returned image is at
+        image resolution. The oversampled JAX path always uses the FFT formalism.
         """
+        if self.convolve_over_sample_size > 1:
+            if xp is np:
+                return self._convolved_image_over_sampled_np_from(
+                    image=image, blurring_image=blurring_image, mask=mask
+                )
+            return self._convolved_image_over_sampled_jax_from(
+                image=image,
+                blurring_image=blurring_image,
+                mask=mask,
+                use_mixed_precision=use_mixed_precision,
+                xp=xp,
+            )
+
         if xp is np:
             return self.convolved_image_via_real_space_np_from(
                 image=image, blurring_image=blurring_image, xp=xp
@@ -654,9 +1083,20 @@ class Convolver:
         ndarray of shape (N_pix, N_src)
             Convolved mapping matrix in slim form.
         """
-        # -------------------------------------------------------------------------
-        # NumPy path unchanged
-        # -------------------------------------------------------------------------
+        if self.convolve_over_sample_size > 1:
+            if xp is np:
+                return self._convolved_mapping_matrix_over_sampled_np_from(
+                    mapping_matrix=mapping_matrix,
+                    mask=mask,
+                    blurring_mapping_matrix=blurring_mapping_matrix,
+                )
+            return self._convolved_mapping_matrix_over_sampled_jax_from(
+                mapping_matrix=mapping_matrix,
+                mask=mask,
+                blurring_mapping_matrix=blurring_mapping_matrix,
+                use_mixed_precision=use_mixed_precision,
+                xp=xp,
+            )
 
         # -------------------------------------------------------------------------
         # NumPy path unchanged
@@ -796,6 +1236,14 @@ class Convolver:
         Array2D
             Convolved image in slim format.
         """
+        if self.convolve_over_sample_size > 1:
+            if xp is np:
+                return self._convolved_image_over_sampled_np_from(
+                    image=image, blurring_image=blurring_image
+                )
+            return self._convolved_image_over_sampled_jax_from(
+                image=image, blurring_image=blurring_image, xp=xp
+            )
 
         if xp is np:
             return self.convolved_image_via_real_space_np_from(
@@ -869,6 +1317,19 @@ class Convolver:
         ndarray (N_pix, N_src)
             Convolved mapping matrix in slim form.
         """
+        if self.convolve_over_sample_size > 1:
+            if xp is np:
+                return self._convolved_mapping_matrix_over_sampled_np_from(
+                    mapping_matrix=mapping_matrix,
+                    mask=mask,
+                    blurring_mapping_matrix=blurring_mapping_matrix,
+                )
+            return self._convolved_mapping_matrix_over_sampled_jax_from(
+                mapping_matrix=mapping_matrix,
+                mask=mask,
+                blurring_mapping_matrix=blurring_mapping_matrix,
+                xp=xp,
+            )
 
         if xp is np:
             return self.convolved_mapping_matrix_via_real_space_np_from(
@@ -902,7 +1363,11 @@ class Convolver:
         return blurred_mapping_matrix_native[state.mask.slim_to_native_tuple]
 
     def convolved_image_via_real_space_np_from(
-        self, image: np.ndarray, blurring_image: Optional[np.ndarray] = None, xp=np
+        self,
+        image: np.ndarray,
+        blurring_image: Optional[np.ndarray] = None,
+        mask: Optional["Mask2D"] = None,
+        xp=np,
     ):
         """
         Convolve an input masked image with this PSF in real space.
@@ -929,6 +1394,10 @@ class Convolver:
         Array2D
             Convolved image in slim format.
         """
+        if self.convolve_over_sample_size > 1:
+            return self._convolved_image_over_sampled_np_from(
+                image=image, blurring_image=blurring_image, mask=mask
+            )
 
         from scipy.signal import convolve as scipy_convolve
 
@@ -996,6 +1465,12 @@ class Convolver:
         ndarray (N_pix, N_src)
             Convolved mapping matrix in slim form.
         """
+        if self.convolve_over_sample_size > 1:
+            return self._convolved_mapping_matrix_over_sampled_np_from(
+                mapping_matrix=mapping_matrix,
+                mask=mask,
+                blurring_mapping_matrix=blurring_mapping_matrix,
+            )
 
         from scipy.signal import convolve as scipy_convolve
 

--- a/autoarray/operators/over_sampling/decorator.py
+++ b/autoarray/operators/over_sampling/decorator.py
@@ -33,6 +33,7 @@ def over_sample(func):
         grid: Union[np.ndarray, Grid2D, Grid2DIrregular, Grid1D],
         xp=np,
         *args,
+        binned: bool = True,
         **kwargs,
     ) -> Union[np.ndarray, Array1D, Array2D, ArrayIrregular, List]:
         """
@@ -43,6 +44,10 @@ def over_sample(func):
             An object whose function uses grid_like inputs to compute quantities at every coordinate on the grid.
         grid
             A grid_like object of coordinates on which the function values are evaluated.
+        binned
+            If False, the values evaluated on the over-sampled grid are returned without binning, in per-pixel
+            sub-block order (the input format of oversampled PSF convolution, see
+            ``Convolver.convolve_over_sample_size``). Ignored for irregular / 1D grids, which are never binned.
 
         Returns
         -------
@@ -56,6 +61,9 @@ def over_sample(func):
             values = func(obj, grid.over_sampled, xp, *args, **kwargs)
         else:
             values = func(grid.over_sampled, xp, *args, **kwargs)
+
+        if not binned:
+            return values
 
         return grid.over_sampler.binned_array_2d_from(array=values, xp=xp)
 

--- a/autoarray/operators/over_sampling/over_sample_util.py
+++ b/autoarray/operators/over_sampling/over_sample_util.py
@@ -47,6 +47,84 @@ def over_sample_size_convert_to_array_2d_from(
     return Array2D(values=np.array(over_sample_size).astype("int"), mask=mask)
 
 
+def mask_2d_upscaled_from(mask_2d: Mask2D, over_sample_size: int) -> Mask2D:
+    """
+    Returns the input mask upscaled by an integer over sample size, where every unmasked pixel becomes an
+    unmasked block of over_sample_size x over_sample_size fine pixels.
+
+    The upscaled mask has pixel scales divided by the over sample size and the same origin, such that the
+    fine pixel centres coincide with the sub-pixel centres of a uniform over-sampled grid of the input mask.
+
+    This is used to perform PSF convolution at a higher resolution than the image (see the `Convolver`
+    object's `convolve_over_sample_size`), where the existing convolution machinery runs unchanged on the
+    upscaled mask.
+
+    Parameters
+    ----------
+    mask_2d
+        The mask defining the image-resolution grid which is upscaled.
+    over_sample_size
+        The integer factor by which the mask is upscaled in each dimension.
+
+    Returns
+    -------
+    The upscaled mask, of shape [total_y_pixels * over_sample_size, total_x_pixels * over_sample_size].
+    """
+    mask_fine = np.repeat(
+        np.repeat(np.array(mask_2d), over_sample_size, axis=0),
+        over_sample_size,
+        axis=1,
+    )
+
+    pixel_scales = (
+        mask_2d.pixel_scales[0] / over_sample_size,
+        mask_2d.pixel_scales[1] / over_sample_size,
+    )
+
+    return Mask2D(mask=mask_fine, pixel_scales=pixel_scales, origin=mask_2d.origin)
+
+
+def sub_slim_to_fine_slim_from(mask_2d: Mask2D, over_sample_size: int) -> np.ndarray:
+    """
+    Returns the permutation mapping every uniform over-sampled (sub-gridded) slim index of a mask to its slim
+    index on the upscaled mask returned by `mask_2d_upscaled_from`.
+
+    Over-sampled arrays are ordered as per-pixel sub-blocks: the s^2 sub-pixels of the first unmasked pixel
+    come first (row-major within the block), then the s^2 sub-pixels of the second unmasked pixel, and so on
+    (see `OverSampler`). The upscaled mask's slim ordering is instead row-major over the whole fine grid.
+    This permutation converts between the two: for a sub-gridded array `values` in sub-block order,
+    `fine_slim[perm] = values` scatters it into fine-mask slim order, and `fine_slim[perm]` gathers it back.
+
+    Parameters
+    ----------
+    mask_2d
+        The mask defining the image-resolution grid.
+    over_sample_size
+        The uniform integer over sample size of the sub-grid.
+
+    Returns
+    -------
+    An integer array of shape [total_unmasked_pixels * over_sample_size**2] whose k-th entry is the fine-mask
+    slim index of the k-th sub-pixel.
+    """
+    s = over_sample_size
+
+    mask = np.array(mask_2d)
+    ny, nx = mask.shape
+
+    fine_slim_index_native = np.full((ny * s, nx * s), -1, dtype="int")
+    mask_fine = np.repeat(np.repeat(mask, s, axis=0), s, axis=1)
+    fine_slim_index_native[~mask_fine] = np.arange(np.sum(~mask_fine))
+
+    ys, xs = np.where(~mask)
+
+    block = np.arange(s)
+    rows = ys[:, None, None] * s + block[None, :, None]
+    cols = xs[:, None, None] * s + block[None, None, :]
+
+    return fine_slim_index_native[rows, cols].reshape(-1)
+
+
 def total_sub_pixels_2d_from(sub_size: np.ndarray) -> int:
     """
     Returns the total number of sub-pixels in unmasked pixels in a mask.

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -410,3 +410,104 @@ def test__psf_not_odd_x_odd_kernel__raises_error():
             noise_map=noise_map,
             psf=psf,
         )
+
+
+def test__convolve_over_sample_size__validation_and_plumbing():
+    data = aa.Array2D.no_mask(values=np.ones((11, 11)), pixel_scales=1.0)
+    noise_map = aa.Array2D.no_mask(values=np.ones((11, 11)), pixel_scales=1.0)
+    kernel_fine = aa.Array2D.no_mask(values=np.ones((9, 9)), pixel_scales=0.5)
+    psf = aa.Convolver(kernel=kernel_fine)
+
+    # convolve size must be a plain int.
+    with pytest.raises(TypeError):
+        aa.Imaging(
+            data=data,
+            noise_map=noise_map,
+            psf=psf,
+            over_sample_size_lp=2,
+            convolve_over_sample_size_lp=2.0,
+        )
+
+    # over_sample_size must equal the convolve size when the latter is above 1.
+    with pytest.raises(aa.exc.DatasetException):
+        aa.Imaging(
+            data=data,
+            noise_map=noise_map,
+            psf=psf,
+            over_sample_size_lp=4,
+            convolve_over_sample_size_lp=2,
+        )
+
+    # Adaptive (non-uniform) over sampling is incompatible with oversampled convolution.
+    sub_size_adaptive = np.full(fill_value=2, shape=data.shape_slim)
+    sub_size_adaptive[0] = 4
+
+    with pytest.raises(aa.exc.DatasetException):
+        aa.Imaging(
+            data=data,
+            noise_map=noise_map,
+            psf=psf,
+            over_sample_size_lp=aa.Array2D(values=sub_size_adaptive, mask=data.mask),
+            convolve_over_sample_size_lp=2,
+        )
+
+    # Differing lp / pixelization convolve sizes are not supported (single PSF kernel).
+    with pytest.raises(aa.exc.DatasetException):
+        aa.Imaging(
+            data=data,
+            noise_map=noise_map,
+            psf=psf,
+            over_sample_size_lp=2,
+            over_sample_size_pixelization=4,
+            convolve_over_sample_size_lp=2,
+            convolve_over_sample_size_pixelization=4,
+        )
+
+    # Valid dataset: the psf carries the convolve size and apply_mask preserves it,
+    # precomputing the fine state and building the blurring grid at the fine resolution.
+    dataset = aa.Imaging(
+        data=data,
+        noise_map=noise_map,
+        psf=psf,
+        over_sample_size_lp=2,
+        convolve_over_sample_size_lp=2,
+    )
+
+    assert dataset.convolve_over_sample_size_lp == 2
+    assert dataset.psf.convolve_over_sample_size == 2
+
+    mask = aa.Mask2D.circular(shape_native=(11, 11), pixel_scales=1.0, radius=3.5)
+    masked = dataset.apply_mask(mask=mask)
+
+    assert masked.convolve_over_sample_size_lp == 2
+    assert masked.psf.convolve_over_sample_size == 2
+    assert masked.psf._state is not None
+    assert masked.psf._state.sub_slim_to_fine_slim is not None
+
+    # The blurring grid footprint uses the kernel's image-resolution shape (5x5 for a
+    # 9x9 fine kernel at s=2) and is evaluated at the fine resolution.
+    blurring_mask = mask.derive_mask.blurring_from(
+        kernel_shape_native=(5, 5), allow_padding=True
+    )
+    assert np.array(masked.grids.blurring.over_sampled).shape == (
+        blurring_mask.pixels_in_mask * 4,
+        2,
+    )
+
+
+def test__convolve_over_sample_size__sparse_operator_guard():
+    data = aa.Array2D.no_mask(values=np.ones((11, 11)), pixel_scales=1.0)
+    noise_map = aa.Array2D.no_mask(values=np.ones((11, 11)), pixel_scales=1.0)
+    kernel_fine = aa.Array2D.no_mask(values=np.ones((9, 9)), pixel_scales=0.5)
+    psf = aa.Convolver(kernel=kernel_fine)
+
+    dataset = aa.Imaging(
+        data=data,
+        noise_map=noise_map,
+        psf=psf,
+        over_sample_size_pixelization=2,
+        convolve_over_sample_size_pixelization=2,
+    )
+
+    with pytest.raises(aa.exc.DatasetException):
+        dataset.apply_sparse_operator()

--- a/test_autoarray/operators/over_sample/test_decorator.py
+++ b/test_autoarray/operators/over_sample/test_decorator.py
@@ -60,3 +60,31 @@ def test__in_grid_2d__over_sample_uniform__out_ndarray_1d():
 
     assert isinstance(ndarray_1d, aa.Array2D)
     assert (ndarray_1d == ndarray_1d_via_grid).all()
+
+
+def test__in_grid_2d__over_sample_uniform__binned_false_returns_sub_values():
+    mask = aa.Mask2D(
+        mask=[
+            [True, True, True, True],
+            [True, False, False, True],
+            [True, False, False, True],
+            [True, True, True, True],
+        ],
+        pixel_scales=(1.0, 1.0),
+    )
+
+    grid_2d = aa.Grid2D.from_mask(mask=mask, over_sample_size=2)
+
+    obj = aa.m.MockGrid2DLikeObj()
+
+    values_sub = obj.ndarray_1d_from(grid=grid_2d, binned=False)
+
+    assert values_sub.shape[0] == mask.pixels_in_mask * 4
+
+    # Binning the unbinned values by the mean of each sub-block reproduces the
+    # decorator's binned output.
+    binned = obj.ndarray_1d_from(grid=grid_2d)
+
+    assert values_sub.reshape(mask.pixels_in_mask, 4).mean(axis=1) == pytest.approx(
+        np.array(binned), abs=1.0e-14
+    )

--- a/test_autoarray/operators/over_sample/test_over_sample_util.py
+++ b/test_autoarray/operators/over_sample/test_over_sample_util.py
@@ -266,3 +266,73 @@ def test__from_adapt():
     )
 
     assert sub_size == pytest.approx([4, 4, 4], 1.0e-4)
+
+
+def test__mask_2d_upscaled_from():
+    mask = aa.Mask2D(
+        mask=[[True, False], [False, True]],
+        pixel_scales=(1.0, 1.0),
+        origin=(1.0, 1.0),
+    )
+
+    mask_fine = util.over_sample.mask_2d_upscaled_from(mask_2d=mask, over_sample_size=2)
+
+    assert mask_fine.shape_native == (4, 4)
+    assert mask_fine.pixel_scales == (0.5, 0.5)
+    assert mask_fine.origin == (1.0, 1.0)
+    assert (
+        np.array(mask_fine)
+        == np.array(
+            [
+                [True, True, False, False],
+                [True, True, False, False],
+                [False, False, True, True],
+                [False, False, True, True],
+            ]
+        )
+    ).all()
+
+
+def test__mask_2d_upscaled_from__size_one_is_identity():
+    mask = aa.Mask2D(mask=[[True, False], [False, True]], pixel_scales=(1.0, 1.0))
+
+    mask_fine = util.over_sample.mask_2d_upscaled_from(mask_2d=mask, over_sample_size=1)
+
+    assert (np.array(mask_fine) == np.array(mask)).all()
+    assert mask_fine.pixel_scales == (1.0, 1.0)
+
+
+def test__sub_slim_to_fine_slim_from():
+    # Two unmasked pixels side by side: their 2x2 sub-blocks interleave row-wise
+    # on the fine grid, so the permutation is not the identity.
+    mask = aa.Mask2D(mask=[[False, False]], pixel_scales=(1.0, 1.0))
+
+    perm = util.over_sample.sub_slim_to_fine_slim_from(mask_2d=mask, over_sample_size=2)
+
+    assert (perm == np.array([0, 1, 4, 5, 2, 3, 6, 7])).all()
+
+
+def test__sub_slim_to_fine_slim_from__size_one_is_identity():
+    mask = aa.Mask2D(
+        mask=[[True, False, True], [False, False, False], [True, False, True]],
+        pixel_scales=(1.0, 1.0),
+    )
+
+    perm = util.over_sample.sub_slim_to_fine_slim_from(mask_2d=mask, over_sample_size=1)
+
+    assert (perm == np.arange(5)).all()
+
+
+def test__sub_slim_to_fine_slim_from__is_bijection_and_round_trips():
+    mask = aa.Mask2D.circular(shape_native=(7, 7), pixel_scales=1.0, radius=2.5)
+
+    perm = util.over_sample.sub_slim_to_fine_slim_from(mask_2d=mask, over_sample_size=3)
+
+    assert perm.size == mask.pixels_in_mask * 9
+    assert np.array_equal(np.sort(perm), np.arange(perm.size))
+
+    values_sub = np.arange(perm.size, dtype="float")
+    fine_slim = np.zeros(perm.size)
+    fine_slim[perm] = values_sub
+
+    assert (fine_slim[perm] == values_sub).all()

--- a/test_autoarray/operators/test_convolver.py
+++ b/test_autoarray/operators/test_convolver.py
@@ -334,3 +334,159 @@ def test__convolve_imaged_from__via_fft__sizes_not_precomputed__compare_numerica
     )
 
     assert blurred_fft.native.array[13, 13] == pytest.approx(249.5, abs=1e-6)
+
+
+def _ground_truth_centres(n, pixel_scale):
+    return (np.arange(n) - (n - 1) / 2.0) * pixel_scale
+
+
+def _ground_truth_gaussian(y, x, sigma, centre=(0.0, 0.0)):
+    r2 = (y - centre[0]) ** 2 + (x - centre[1]) ** 2
+    return (1.0 / (sigma * np.sqrt(2.0 * np.pi))) * np.exp(-0.5 * r2 / sigma**2)
+
+
+def _ground_truth_scene(over_sample_size):
+    """
+    The brute-force reference scene of PyAutoMind/feature/autoarray/oversampling_ground_truth.py:
+    11x11 image at ps=1", circular mask r=3.5" (37 pixels), Gaussian source (sigma=1.2",
+    centre (0.3, -0.4)"), Gaussian PSF (sigma=0.8") with fixed physical kernel radius 2.0".
+    """
+    s = over_sample_size
+
+    mask = aa.Mask2D.circular(shape_native=(11, 11), pixel_scales=1.0, radius=3.5)
+
+    kernel_n = int(2 * round(2.0 * s) + 1)
+    kc = _ground_truth_centres(kernel_n, 1.0 / s)
+    kyy, kxx = np.meshgrid(-kc, kc, indexing="ij")
+    kernel = aa.Array2D.no_mask(
+        values=_ground_truth_gaussian(kyy, kxx, 0.8), pixel_scales=1.0 / s
+    )
+
+    convolver = aa.Convolver(
+        kernel=kernel, normalize=True, convolve_over_sample_size=s
+    )
+
+    grid = aa.Grid2D.from_mask(mask=mask, over_sample_size=s)
+
+    blurring_mask = mask.derive_mask.blurring_from(
+        kernel_shape_native=convolver.kernel_shape_image_resolution,
+        allow_padding=True,
+    )
+    blurring_grid = aa.Grid2D.from_mask(mask=blurring_mask, over_sample_size=s)
+
+    def eval_source(grid_over_sampled):
+        arr = np.array(grid_over_sampled)
+        return _ground_truth_gaussian(arr[:, 0], arr[:, 1], 1.2, (0.3, -0.4))
+
+    image = eval_source(grid.over_sampled)
+    blurring_image = eval_source(blurring_grid.over_sampled)
+
+    return mask, convolver, image, blurring_image
+
+
+def test__convolve_over_sample_size__matches_brute_force_ground_truth():
+    mask, convolver, image, blurring_image = _ground_truth_scene(over_sample_size=2)
+
+    convolved = convolver.convolved_image_from(
+        image=image, blurring_image=blurring_image, mask=mask
+    )
+    convolved = np.array(convolved)
+
+    assert convolved.sum() == pytest.approx(2.796562184524787e00, abs=1.0e-12)
+    assert convolved[0] == pytest.approx(3.726289901353439e-02, abs=1.0e-12)
+    assert convolved[17] == pytest.approx(2.025075336159483e-01, abs=1.0e-12)
+    assert convolved[36] == pytest.approx(1.090767109119494e-02, abs=1.0e-12)
+
+
+def test__convolve_over_sample_size_one__scene_matches_ground_truth():
+    # The same scene through the unchanged s=1 path reproduces the brute-force
+    # reference, pinning the test scene itself against the ground-truth script.
+    mask, convolver, image, blurring_image = _ground_truth_scene(over_sample_size=1)
+
+    image = aa.Array2D(values=image, mask=mask)
+    blurring_mask = mask.derive_mask.blurring_from(
+        kernel_shape_native=(5, 5), allow_padding=True
+    )
+    blurring_image = aa.Array2D(values=blurring_image, mask=blurring_mask)
+
+    convolved = convolver.convolved_image_via_real_space_np_from(
+        image=image, blurring_image=blurring_image
+    )
+    convolved = np.array(convolved)
+
+    assert convolved.sum() == pytest.approx(2.807349652595196e00, abs=1.0e-12)
+    assert convolved[0] == pytest.approx(3.655472905370449e-02, abs=1.0e-12)
+    assert convolved[17] == pytest.approx(2.069771979137382e-01, abs=1.0e-12)
+    assert convolved[36] == pytest.approx(1.042470837248629e-02, abs=1.0e-12)
+
+
+def test__convolve_over_sample_size__mapping_matrix__delta_kernel_bins_rows():
+    # With a delta-function fine kernel, oversampled convolution reduces to
+    # binning the sub-resolution mapping matrix rows by their mean, testing the
+    # permutation and bin-down independently of convolution numerics.
+    mask = aa.Mask2D.circular(shape_native=(7, 7), pixel_scales=1.0, radius=2.5)
+    s = 2
+
+    delta = np.zeros((3, 3))
+    delta[1, 1] = 1.0
+    kernel = aa.Array2D.no_mask(values=delta, pixel_scales=1.0 / s)
+
+    convolver = aa.Convolver(kernel=kernel, convolve_over_sample_size=s)
+
+    n_sub = mask.pixels_in_mask * s**2
+    rng = np.random.default_rng(1)
+    mapping_matrix = rng.random((n_sub, 3))
+
+    convolved = convolver.convolved_mapping_matrix_from(
+        mapping_matrix=mapping_matrix, mask=mask
+    )
+
+    binned = mapping_matrix.reshape(mask.pixels_in_mask, s**2, 3).mean(axis=1)
+
+    assert convolved == pytest.approx(binned, abs=1.0e-14)
+
+
+def test__convolve_over_sample_size__validation():
+    kernel_native = aa.Array2D.no_mask(values=np.ones((3, 3)), pixel_scales=1.0)
+    kernel_fine = aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=0.5)
+
+    with pytest.raises(TypeError):
+        aa.Convolver(kernel=kernel_native, convolve_over_sample_size=2.0)
+
+    with pytest.raises(aa.exc.KernelException):
+        aa.Convolver(kernel=kernel_native, convolve_over_sample_size=0)
+
+    mask = aa.Mask2D.circular(shape_native=(7, 7), pixel_scales=1.0, radius=2.5)
+
+    # Kernel at image resolution handed to an oversampled convolver.
+    convolver = aa.Convolver(kernel=kernel_native, convolve_over_sample_size=2)
+    with pytest.raises(aa.exc.KernelException):
+        convolver.state_from(mask=mask)
+
+    convolver = aa.Convolver(kernel=kernel_fine, convolve_over_sample_size=2)
+
+    # Binned (image-resolution) input is a distinct, explicit error.
+    with pytest.raises(aa.exc.KernelException):
+        convolver.convolved_image_from(
+            image=np.ones(mask.pixels_in_mask), blurring_image=None, mask=mask
+        )
+
+    # No precomputed state and no mask.
+    with pytest.raises(aa.exc.KernelException):
+        convolver.convolved_image_from(
+            image=np.ones(mask.pixels_in_mask * 4), blurring_image=None
+        )
+
+
+def test__kernel_shape_image_resolution():
+    kernel = aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=1.0)
+    convolver = aa.Convolver(kernel=kernel)
+    assert convolver.kernel_shape_image_resolution == (5, 5)
+
+    kernel_fine = aa.Array2D.no_mask(values=np.ones((9, 9)), pixel_scales=0.5)
+    convolver = aa.Convolver(kernel=kernel_fine, convolve_over_sample_size=2)
+    assert convolver.kernel_shape_image_resolution == (5, 5)
+
+    kernel_fine = aa.Array2D.no_mask(values=np.ones((15, 15)), pixel_scales=1.0 / 3.0)
+    convolver = aa.Convolver(kernel=kernel_fine, convolve_over_sample_size=3)
+    assert convolver.kernel_shape_image_resolution == (7, 7)


### PR DESCRIPTION
## Summary

Oversampled PSF convolution, phase 2a (core API) of the feature designed and approved in #353: `Convolver` gains `convolve_over_sample_size`, so PSF blurring can run at an integer multiple of the image resolution (the PSF supplied at that fine resolution) and bin back down by the mean of each sub-block — improving blurring accuracy for modeling. The implementation reuses the existing convolution machinery verbatim on an upscaled mask, plus a cached permutation between autoarray's per-pixel sub-block ordering and the fine mask's row-major slim ordering. Behaviour at the default `convolve_over_sample_size=1` is unchanged.

Tracks #354. Design note + brute-force numerical ground truth: `PyAutoMind/feature/autoarray/` (`oversampling_design.md`, `oversampling_ground_truth.py`).

## API Changes

All changes are additive; `convolve_over_sample_size=1` (default) leaves every existing code path untouched.

- `Convolver(convolve_over_sample_size: int = 1)` — kernel supplied at the fine resolution when > 1; new `kernel_shape_image_resolution` property; convolution methods expect over-sampled (sub-block ordered) inputs when > 1 and raise `KernelException` on binned input; optional `mask=` keyword on the image-convolution methods; the oversampled JAX path always uses the FFT formalism.
- `Imaging(convolve_over_sample_size_lp=1, convolve_over_sample_size_pixelization=1)` — with loud guards: matching `over_sample_size_*` must be uniform and equal when > 1; differing lp/pixelization sizes raise; incompatible with `sparse_operator`. `from_fits` gains the two sizes + `psf_pixel_scales`; `apply_mask`/`apply_over_sampling` pass through.
- `GridsDataset.blurring` — footprint from the kernel's image-resolution shape, evaluated at the fine resolution when oversampled.
- `over_sample` decorator — keyword-only `binned: bool = True`; `False` returns sub-block-ordered values.
- New utils: `mask_2d_upscaled_from`, `sub_slim_to_fine_slim_from`; `ConvolverState` gains an optional explicit `blurring_mask`.

See full details below.

## Test Plan
- [x] 13 new unit tests: s=2 output pinned to the phase-1 brute-force ground truth to ≤1e-12; s=1 scene parity; permutation bijection/round-trip; delta-kernel mapping-matrix identity; all validation guards.
- [x] Full suites against this branch: PyAutoArray 857 passed, PyAutoGalaxy 933 passed, PyAutoLens 331 passed.

## Validation checklist (--auto run — plan was not pre-approved in-session)
- Effective level: supervised (header: supervised, cap: feature → supervised)
- Plan: on the issue (#354), written at start, unmodified since; design pre-approved in #353
- Gate: tests 857+933+331 pass · smoke n/a (additive behind default=1; human waived at sign-off) · review CLEAN · Heart YELLOW (chronic reason set surfaced at sign-off; human approved ship)
- [x] Human: ship approved on the issue sign-off question (2026-07-08)
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `Convolver(convolve_over_sample_size: int = 1)` — over sample size of the PSF; size 2 = PSF at 2× the image resolution (kernel pixel scales = image pixel scales / size, validated at state construction).
- `Convolver.kernel_shape_image_resolution` — the kernel footprint in image-resolution pixels (drives the blurring-mask derivation).
- `Convolver.convolved_image_from(..., mask=None)` / `convolved_image_via_real_space_np_from(..., mask=None)` — optional keyword; required when oversampled and no precomputed state exists (over-sampled inputs carry no mask). Keyword-only in practice; all downstream call sites verified keyword-based.
- `ConvolverState(..., blurring_mask=None)` — explicit blurring-mask override; the FFT frame is sized to retain an explicit blurring region.
- `Imaging(convolve_over_sample_size_lp: int = 1, convolve_over_sample_size_pixelization: int = 1)` — plumbed through `from_fits` (+ `psf_pixel_scales`), `apply_mask`, `apply_over_sampling`; `psf_setup_state=True` precomputes the fine state.
- `over_sample` decorator: keyword-only `binned: bool = True`.
- `over_sample_util.mask_2d_upscaled_from(mask_2d, over_sample_size)`.
- `over_sample_util.sub_slim_to_fine_slim_from(mask_2d, over_sample_size)`.

### Changed-Behaviour (only when convolve_over_sample_size > 1)
- Convolution methods take over-sampled (sub-block ordered) inputs and return image-resolution outputs.
- `GridsDataset.blurring` is built at the fine resolution with the image-resolution footprint.

### Guards (raise loudly)
- Non-int / < 1 `convolve_over_sample_size*` → `TypeError` / `KernelException`/`DatasetException`.
- `over_sample_size_*` not uniform-and-equal when oversampled → `DatasetException`.
- Differing lp/pixelization convolve sizes → `DatasetException` (single PSF kernel).
- `sparse_operator` (ctor or `apply_sparse_operator`) with an oversampled PSF → `DatasetException`.
- Binned input, kernel/pixel-scale mismatch, missing mask+state → `KernelException`.

### Deferred (per approved phasing)
- Inversion wiring (phase 2b): an oversampled Convolver raises if handed a binned mapping matrix, so pixelized fits cannot silently mis-run.
- PyAutoGalaxy `operate/image.py` consumer switch (phase 2c); workspace examples (phase 3); docs (phase 4).

### Migration
- No migration; existing code is unaffected. To opt in: supply the PSF at s× the image resolution and pass `convolve_over_sample_size_lp=s` with `over_sample_size_lp=s`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
