### PR TITLE
feat: oversampled PSF inversion wiring — mapping formalism (phase 2b)

### DIFF
--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -10,6 +10,7 @@ from autoarray.inversion.linear_obj.linear_obj import LinearObj
 from autoarray.settings import Settings
 
 from autoarray.inversion.inversion.imaging import inversion_imaging_util
+from autoarray import exc
 
 
 class AbstractInversionImaging(AbstractInversion):
@@ -73,6 +74,31 @@ class AbstractInversionImaging(AbstractInversion):
     def psf(self):
         return self.dataset.psf
 
+    def _mapping_matrix_for_convolution_from(self, linear_obj) -> np.ndarray:
+        """
+        The mapping matrix a linear object contributes to PSF convolution.
+
+        For a regular PSF this is the image-resolution `mapping_matrix`. For an
+        oversampled PSF (`convolve_over_sample_size > 1`) convolution must happen
+        before the sub-pixel fold, so a `Mapper` contributes its
+        `mapping_matrix_over_sampled`; linear function objects are evaluated at
+        image resolution and cannot be convolved at the fine resolution, so they
+        raise (deferred formalism — see the design approved in #353, phase 2b).
+        """
+        if self.psf.convolve_over_sample_size == 1:
+            return linear_obj.mapping_matrix
+
+        if isinstance(linear_obj, Mapper):
+            return linear_obj.mapping_matrix_over_sampled
+
+        raise exc.InversionException(
+            "Oversampled PSF convolution (convolve_over_sample_size > 1) currently "
+            "supports Mapper linear objects only. Linear function objects (e.g. "
+            "linear light profiles without an operated override) are evaluated at "
+            "image resolution and their fine-resolution convolution is deferred "
+            "future work."
+        )
+
     @property
     def mapping_matrix_list(self) -> List[np.ndarray]:
         """
@@ -104,7 +130,9 @@ class AbstractInversionImaging(AbstractInversion):
         return [
             (
                 self.psf.convolved_mapping_matrix_from(
-                    mapping_matrix=linear_obj.mapping_matrix,
+                    mapping_matrix=self._mapping_matrix_for_convolution_from(
+                        linear_obj
+                    ),
                     mask=self.mask,
                     use_mixed_precision=self.settings.use_mixed_precision,
                     xp=self._xp,
@@ -173,7 +201,9 @@ class AbstractInversionImaging(AbstractInversion):
                 operated_mapping_matrix = linear_func.operated_mapping_matrix_override
             else:
                 operated_mapping_matrix = self.psf.convolved_mapping_matrix_from(
-                    mapping_matrix=linear_func.mapping_matrix,
+                    mapping_matrix=self._mapping_matrix_for_convolution_from(
+                        linear_func
+                    ),
                     mask=self.mask,
                     xp=self._xp,
                 )
@@ -214,6 +244,13 @@ class AbstractInversionImaging(AbstractInversion):
             A matrix of shape [data_pixels, total_fixed_linear_functions] that for each data pixel, maps it to the sum
             of the values of a linear object function convolved with the PSF kernel at the data pixel.
         """
+        if self.psf.convolve_over_sample_size > 1:
+            raise exc.InversionException(
+                "The data_linear_func_matrix preload consumes the PSF kernel at "
+                "image resolution and is incompatible with an oversampled PSF "
+                "(convolve_over_sample_size > 1)."
+            )
+
         linear_func_list = self.cls_list_from(cls=AbstractLinearObjFuncList)
 
         data_linear_func_matrix_dict = {}
@@ -255,7 +292,9 @@ class AbstractInversionImaging(AbstractInversion):
 
         for mapper in self.cls_list_from(cls=Mapper):
             operated_mapping_matrix = self.psf.convolved_mapping_matrix_from(
-                mapping_matrix=mapper.mapping_matrix, mask=self.mask, xp=self._xp
+                mapping_matrix=self._mapping_matrix_for_convolution_from(mapper),
+                mask=self.mask,
+                xp=self._xp,
             )
 
             mapper_operated_mapping_matrix_dict[mapper] = operated_mapping_matrix

--- a/autoarray/inversion/inversion/imaging/sparse.py
+++ b/autoarray/inversion/inversion/imaging/sparse.py
@@ -13,6 +13,7 @@ from autoarray.inversion.mappers.abstract import Mapper
 from autoarray.structures.arrays.uniform_2d import Array2D
 
 from autoarray.inversion.inversion.imaging import inversion_imaging_util
+from autoarray import exc
 
 
 class InversionImagingSparse(AbstractInversionImaging):
@@ -52,6 +53,13 @@ class InversionImagingSparse(AbstractInversionImaging):
 
     @cached_property
     def psf_weighted_data(self):
+        if self.psf.convolve_over_sample_size > 1:
+            raise exc.InversionException(
+                "The sparse linear algebra formalism precomputes PSF products at "
+                "image resolution and is incompatible with an oversampled PSF "
+                "(convolve_over_sample_size > 1)."
+            )
+
         return inversion_imaging_util.psf_weighted_data_from(
             weight_map_native=self.dataset.sparse_operator.weight_map.array,
             kernel_native=self.psf.kernel.native,

--- a/autoarray/inversion/mappers/abstract.py
+++ b/autoarray/inversion/mappers/abstract.py
@@ -278,6 +278,36 @@ class Mapper(LinearObj):
         )
 
     @cached_property
+    def mapping_matrix_over_sampled(self) -> np.ndarray:
+        """
+        The `mapping_matrix` at the over-sampled (sub-pixel) resolution: one row per
+        data sub-pixel in per-pixel sub-block order, with no `sub_fraction` fold.
+
+        The regular `mapping_matrix` sums each pixel's sub-pixel contributions
+        (weighted by `sub_fraction = 1/sub_size^2`) down to image resolution before
+        any PSF operation. Oversampled PSF convolution
+        (`Convolver.convolve_over_sample_size > 1`) must convolve *before* that fold,
+        so it consumes this matrix instead; binning its rows by the mean of each
+        sub-block reproduces `mapping_matrix` exactly.
+
+        The matrix has shape [total_sub_pixels, source_pixels] and is the input
+        format of `Convolver.convolved_mapping_matrix_from` when oversampled.
+        """
+        total_sub_pixels = int(self.over_sampler.sub_total)
+
+        return mapper_util.mapping_matrix_from(
+            pix_indexes_for_sub_slim_index=self.pix_indexes_for_sub_slim_index,
+            pix_size_for_sub_slim_index=self.pix_sizes_for_sub_slim_index,
+            pix_weights_for_sub_slim_index=self.pix_weights_for_sub_slim_index,
+            pixels=self.pixels,
+            total_mask_pixels=total_sub_pixels,
+            slim_index_for_sub_slim_index=np.arange(total_sub_pixels),
+            sub_fraction=np.ones(total_sub_pixels),
+            use_mixed_precision=self.settings.use_mixed_precision,
+            xp=self._xp,
+        )
+
+    @cached_property
     def sparse_triplets_data(self):
         """
         Sparse triplet representation of the (unblurred) mapping operator on the *slim data grid*.

--- a/autoarray/operators/mock/mock_psf.py
+++ b/autoarray/operators/mock/mock_psf.py
@@ -4,6 +4,7 @@ import numpy as np
 class MockPSF:
     def __init__(self, operated_mapping_matrix=None):
         self.operated_mapping_matrix = operated_mapping_matrix
+        self.convolve_over_sample_size = 1
 
     def convolved_mapping_matrix_from(
         self, mapping_matrix, mask, use_mixed_precision=False, xp=np

--- a/test_autoarray/inversion/inversion/imaging/test_imaging.py
+++ b/test_autoarray/inversion/inversion/imaging/test_imaging.py
@@ -132,3 +132,113 @@ def test__curvature_matrix(rectangular_mapper_7x7_3x3):
 
     assert inversion.curvature_matrix[0, 0] - 10.0 > 0.0
     assert inversion.curvature_matrix[3, 3] - 2.0 < 1.0e-12
+
+
+def test__mapping_matrix_over_sampled__delta_kernel_bins_to_mapping_matrix(
+    rectangular_mapper_7x7_3x3,
+):
+    # Binning the sub-resolution mapping matrix rows by the mean of each sub-block
+    # must reproduce the regular (sub_fraction folded) mapping matrix exactly.
+    mapper = rectangular_mapper_7x7_3x3
+    s = 2
+
+    mapping_matrix = np.array(mapper.mapping_matrix)
+    mapping_matrix_sub = np.array(mapper.mapping_matrix_over_sampled)
+
+    assert mapping_matrix_sub.shape == (
+        mapper.mask.pixels_in_mask * s**2,
+        mapping_matrix.shape[1],
+    )
+
+    binned = mapping_matrix_sub.reshape(
+        mapper.mask.pixels_in_mask, s**2, mapping_matrix.shape[1]
+    ).mean(axis=1)
+
+    assert binned == pytest.approx(mapping_matrix, abs=1.0e-14)
+
+
+def _oversampled_psf_for(mask, s, kernel_n=5, sigma_frac=0.4):
+    ps = mask.pixel_scales[0]
+    c = (np.arange(kernel_n) - (kernel_n - 1) / 2.0) * (ps / s)
+    yy, xx = np.meshgrid(-c, c, indexing="ij")
+    kernel = np.exp(-0.5 * (yy**2 + xx**2) / (sigma_frac * ps) ** 2)
+    kernel = kernel / kernel.sum()
+    kernel = aa.Array2D.no_mask(values=kernel, pixel_scales=ps / s)
+    return aa.Convolver(kernel=kernel, convolve_over_sample_size=s)
+
+
+def test__operated_mapping_matrix__oversampled_psf__matches_brute_force(
+    rectangular_mapper_7x7_3x3,
+):
+    # End-to-end mapping-formalism check: the oversampled operated mapping matrix
+    # equals an independent brute-force fine-raster convolution + mean bin-down of
+    # the sub-resolution mapping matrix (implemented with plain loops, not the
+    # Convolver's own indexing).
+    from scipy.signal import convolve as scipy_convolve
+
+    mapper = rectangular_mapper_7x7_3x3
+    mask = mapper.mask
+    s = 2
+
+    psf = _oversampled_psf_for(mask=mask, s=s)
+
+    inversion = aa.m.MockInversionImaging(
+        mask=mask, psf=psf, linear_obj_list=[mapper]
+    )
+
+    operated = np.array(inversion.operated_mapping_matrix_list[0])
+
+    mapping_matrix_sub = np.array(mapper.mapping_matrix_over_sampled)
+    n_src = mapping_matrix_sub.shape[1]
+
+    mask_arr = np.array(mask)
+    ny, nx = mask_arr.shape
+    ys, xs = np.where(~mask_arr)
+
+    native = np.zeros((ny * s, nx * s, n_src))
+    k = 0
+    for yi, xi in zip(ys, xs):
+        for iy in range(s):
+            for ix in range(s):
+                native[yi * s + iy, xi * s + ix, :] = mapping_matrix_sub[k]
+                k += 1
+
+    kernel_fine = np.array(psf.kernel.native)
+    convolved = np.zeros_like(native)
+    for j in range(n_src):
+        convolved[:, :, j] = scipy_convolve(
+            native[:, :, j], kernel_fine, mode="same"
+        )
+
+    brute = convolved.reshape(ny, s, nx, s, n_src).mean(axis=(1, 3))[~mask_arr]
+
+    assert operated == pytest.approx(brute, abs=1.0e-12)
+
+
+def test__oversampled_psf__linear_func_and_preload_guards(
+    rectangular_mapper_7x7_3x3,
+):
+    mapper = rectangular_mapper_7x7_3x3
+    mask = mapper.mask
+
+    psf = _oversampled_psf_for(mask=mask, s=2)
+
+    linear_obj = aa.m.MockLinearObjFuncList(
+        parameters=1, grid=None, mapping_matrix=np.ones((9, 1))
+    )
+
+    inversion = aa.m.MockInversionImaging(
+        mask=mask, psf=psf, linear_obj_list=[linear_obj]
+    )
+
+    # Linear function objects are image-resolution; the oversampled path raises.
+    with pytest.raises(exc.InversionException):
+        inversion.operated_mapping_matrix_list
+
+    inversion = aa.m.MockInversionImaging(
+        mask=mask, psf=psf, linear_obj_list=[mapper]
+    )
+
+    # The kernel-native preload fast path raises too.
+    with pytest.raises(exc.InversionException):
+        inversion.data_linear_func_matrix_dict


### PR DESCRIPTION
## Summary

Oversampled PSF convolution, phase 2b (inversion wiring) of the feature designed in #353: pixelized reconstructions via the **mapping formalism** now convolve at the fine resolution when the dataset's PSF is oversampled. The mapper contributes a new sub-resolution `mapping_matrix_over_sampled` (one row per sub-pixel, no `sub_fraction` fold), which the phase-2a Convolver convolves on the fine grid and bins back — convolution now happens *before* the sub-pixel fold, as the physics requires. `mapping.py` itself needed no logic change: the PSF application site is the shared `AbstractInversionImaging.operated_mapping_matrix_list`, exactly as the approved design recorded.

Tracks #356. Builds on #355 (phase 2a).

## API Changes

Additive; nothing changes while `convolve_over_sample_size == 1`.

- `Mapper.mapping_matrix_over_sampled` — sub-resolution mapping matrix, shape `[total_sub_pixels, source_pixels]` in per-pixel sub-block order (the 2a Convolver input format). Binning its rows by the mean of each sub-block reproduces `mapping_matrix` exactly (tested).
- `AbstractInversionImaging` routes every PSF-convolution site (`operated_mapping_matrix_list`, `linear_func_operated_mapping_matrix_dict`, `mapper_operated_mapping_matrix_dict`) through a single helper that picks the sub-resolution matrix for `Mapper` objects when the PSF is oversampled.
- Loud guards (`InversionException`) on the formalisms that consume `psf.kernel.native` at image resolution and are deferred per the design: linear-function objects without an operated override, the `data_linear_func_matrix` preload, and `InversionImagingSparse.psf_weighted_data`.
- `MockPSF` gains `convolve_over_sample_size = 1` to match the real interface.

## Test Plan
- [x] `mapping_matrix_over_sampled` delta-kernel identity: mean-binned rows == `mapping_matrix` to 1e-14.
- [x] End-to-end s=2: `operated_mapping_matrix_list` matches an independent brute-force fine-raster convolution + bin (plain loops, no shared indexing) to 1e-12.
- [x] Guard tests: linear-func objects and the kernel-native preload raise under an oversampled PSF.
- [x] Full suites against this branch: PyAutoArray / PyAutoGalaxy / PyAutoLens (counts in the issue sign-off).

## Memory profile (design §4 risk)

Native FFT cube `(ny·s, nx·s, n_src)`, fp64, for a realistic strong-lens case (fft frame 256² at s=1):

| s | frame | 500 src | 1000 src | 2000 src |
|---|-------|---------|----------|----------|
| 1 | 256² | 0.26 GB | 0.52 GB | 1.05 GB |
| 2 | 512² | 1.05 GB | 2.10 GB | 4.19 GB |
| 3 | 768² | 2.36 GB | 4.72 GB | 9.44 GB |

s=2 with ~1000 sources is ~2.1 GB (×4 the s=1 cube) plus FFT transients — fine on A100-class GPUs, tight on small (6 GB) cards. Oversampled inversion stays **opt-in** (nothing defaults on); chunked per-column convolution and/or `use_mixed_precision` are the mitigations if profiling shows pressure in practice.

## Validation checklist (--auto run)
- Effective level: supervised (header: supervised, cap: feature → supervised)
- Plan: on the issue (#356), written at filing; design pre-approved in #353; predecessor #355 merged
- Gate: tests full suites pass (counts on the issue) · smoke n/a (opt-in feature, no default-path change) · review CLEAN · Heart YELLOW (chronic set, human-driven session)
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)
