### PR TITLE
feat: catalogue-size cap for PYAUTO_SMALL_DATASETS smoke mode

### DIFF
--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -71,3 +71,25 @@ def should_simulate(dataset_path):
             shutil.rmtree(dataset_path)
 
     return not Path(dataset_path).exists()
+
+SMALL_DATASETS_N_CATALOGUE = 25
+
+
+def cap_catalogue_size_for_small_datasets(n: int) -> int:
+    """
+    Cap a catalogue-style dataset size (e.g. the number of weak-lensing background
+    galaxies) to the small-datasets limit when ``PYAUTO_SMALL_DATASETS=1`` is active.
+
+    Catalogue datasets have no pixel grid, so the (15, 15) array cap above does not
+    apply to them; the number of catalogue entries is their size lever. Returns ``n``
+    unchanged when the env var is not set to ``"1"`` or ``n`` is already at-or-below
+    the cap (25).
+
+    Simulators should apply this to *generated* catalogue sizes only (e.g. a
+    requested number of random positions) — never to a user-provided grid or
+    catalogue, which must round-trip unmodified.
+    """
+    if os.environ.get("PYAUTO_SMALL_DATASETS") != "1":
+        return n
+
+    return min(n, SMALL_DATASETS_N_CATALOGUE)

--- a/test_autoarray/util/test_catalogue_cap.py
+++ b/test_autoarray/util/test_catalogue_cap.py
@@ -1,0 +1,14 @@
+from autoarray.util import dataset_util
+
+
+def test__cap_catalogue_size__inactive_without_env_var(monkeypatch):
+    monkeypatch.delenv("PYAUTO_SMALL_DATASETS", raising=False)
+
+    assert dataset_util.cap_catalogue_size_for_small_datasets(200) == 200
+
+
+def test__cap_catalogue_size__caps_when_active(monkeypatch):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    assert dataset_util.cap_catalogue_size_for_small_datasets(200) == 25
+    assert dataset_util.cap_catalogue_size_for_small_datasets(10) == 10


### PR DESCRIPTION
## Summary
Adds `SMALL_DATASETS_N_CATALOGUE = 25` + `cap_catalogue_size_for_small_datasets(n)` to `autoarray/util/dataset_util.py`, beside the existing pixel caps — catalogue-shaped datasets (weak-lensing shear catalogues; reusable by other catalogue types) have no pixel grid, so entry count is their smoke-mode lever. Applies to generated sizes only, never user-provided grids. Weak series step 9 (PyAutoLabs/PyAutoLens#583); merge this **before** the companion PyAutoLens PR (upstream-first).

## API Changes
Added only: `aa.util.dataset.SMALL_DATASETS_N_CATALOGUE`, `aa.util.dataset.cap_catalogue_size_for_small_datasets(n)`.

## Validation checklist (--auto run)
- Effective level: supervised · plan on PyAutoLabs/PyAutoLens#583 · tests 869-pass (+2 new) · review human sign-off on #583 · Heart YELLOW (acknowledged set)
- [x] Human: ship approved on PyAutoLabs/PyAutoLens#583
- [ ] Human: merge first, then the PyAutoLens PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)