### PR TITLE
feat: PreloadsInterferometer passes mesh-geometry fields through (D5 follow-up)

### DIFF
--- a/autoarray/preloads/interferometer.py
+++ b/autoarray/preloads/interferometer.py
@@ -2,7 +2,13 @@ from autoarray.preloads.abstract import AbstractPreloads
 
 
 class PreloadsInterferometer(AbstractPreloads):
-    def __init__(self, curvature_matrix=None, mapper_galaxy_dict=None):
+    def __init__(
+        self,
+        curvature_matrix=None,
+        mapper_galaxy_dict=None,
+        source_plane_mesh_grid=None,
+        image_plane_mesh_grid=None,
+    ):
         """
         Preloaded quantities for an interferometer fit / inversion (see `AbstractPreloads`).
 
@@ -24,5 +30,8 @@ class PreloadsInterferometer(AbstractPreloads):
             The pre-computed mapper(s) and their source association. See `AbstractPreloads`.
         """
         super().__init__(
-            curvature_matrix=curvature_matrix, mapper_galaxy_dict=mapper_galaxy_dict
+            curvature_matrix=curvature_matrix,
+            mapper_galaxy_dict=mapper_galaxy_dict,
+            source_plane_mesh_grid=source_plane_mesh_grid,
+            image_plane_mesh_grid=image_plane_mesh_grid,
         )

--- a/test_autoarray/preloads/test_preloads.py
+++ b/test_autoarray/preloads/test_preloads.py
@@ -27,3 +27,9 @@ def test__preloads_interferometer__mesh_fields_available_via_abstract():
     assert preloads.curvature_matrix == "F"
     assert preloads.source_plane_mesh_grid is None
     assert preloads.image_plane_mesh_grid is None
+
+    preloads = aa.PreloadsInterferometer(
+        curvature_matrix="F", source_plane_mesh_grid=[["mesh"]], image_plane_mesh_grid=[["im"]]
+    )
+    assert preloads.source_plane_mesh_grid == [["mesh"]]
+    assert preloads.image_plane_mesh_grid == [["im"]]


### PR DESCRIPTION
## Summary

Follow-up to #380 completing the D5 cross-dataset-type contract (design PyAutoLens#599): `PreloadsInterferometer` now passes the mesh-geometry fields (`source_plane_mesh_grid`, `image_plane_mesh_grid`) through to `AbstractPreloads`, so an interferometer lead factor in a joint imaging + interferometer graph can carry the shared source-plane mesh alongside its channel-invariant curvature matrix + mapper.

Paired with the PyAutoLens scoped-consumption PR (must merge together; this one first).

## API Changes
Additive only: `PreloadsInterferometer(... , source_plane_mesh_grid=None, image_plane_mesh_grid=None)`.

## Test Plan
- [x] `test_autoarray/` full suite (897 passed); `test_autoarray/preloads/test_preloads.py` extended for the pass-through
- [x] Downstream `test_autogalaxy/` (962) + `test_autolens/` (381) against the paired branch
- [x] Datacube + multi shared_preloads parity scripts against this branch (see issue PyAutoArray#379 thread / autolens_workspace#260)

## Autonomy
`--auto` safe continuation of the phase 2 run (four-leg gate; Heart YELLOW reason set unchanged from the user's in-session ack). Ends at PR-open; merge stays human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
