### PR TITLE
fix: pin tfp-nightly for JAX Matern-kernel path (tfp 0.25.0 × jax 0.10.2 crash)

### DIFF
--- a/autoarray/inversion/regularization/matern_kernel.py
+++ b/autoarray/inversion/regularization/matern_kernel.py
@@ -17,8 +17,14 @@ def kv_xp(v, z, xp=np):
         -> scipy.special.kv
 
     JAX backend:
-        -> jax.scipy.special.kv if available
-        -> else tfp.substrates.jax.math.bessel_kve * exp(-|z|)
+        -> tensorflow_probability.substrates.jax.math.bessel_kve * exp(-|z|)
+
+    `jax.scipy.special` has no modified-Bessel-K (`kv`/`kve`) of arbitrary real
+    order, so the JAX path relies on tfp's `bessel_kve`. Note the tfp dependency
+    is the *nightly* build (`tfp-nightly`): the last stable release
+    (`tensorflow-probability==0.25.0`) crashes at import under the resolved
+    `jax>=0.7` stack (it references `jax.interpreters.xla.pytype_aval_mappings`,
+    removed from modern JAX).
     """
 
     # -------------------------
@@ -39,8 +45,10 @@ def kv_xp(v, z, xp=np):
             return tfp.math.bessel_kve(v, z) * xp.exp(-xp.abs(z))
         except ImportError:
             raise ImportError(
-                "To use the JAX backend with the Matérn kernel, "
-                "please install tensorflow-probability via `pip install tensorflow-probability==0.25.0`."
+                "To use the JAX backend with the Matérn kernel, install the "
+                "tensorflow-probability nightly via "
+                "`pip install tfp-nightly==0.26.0.dev20260713` "
+                "(the last stable release, 0.25.0, is incompatible with modern JAX)."
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,13 @@ optional = [
     "numba",
     "nufftax>=0.4.0,<0.5.0; python_version >= '3.12'",
     "pynufft",
-    "tensorflow-probability==0.25.0"
+    # tfp provides the modified-Bessel `bessel_kve` used by the JAX Matern-kernel
+    # regularization path (autoarray/inversion/regularization/matern_kernel.py).
+    # The last *stable* release (tensorflow-probability==0.25.0) targets a JAX where
+    # `jax.interpreters.xla.pytype_aval_mappings` still existed; it crashes at import
+    # under the resolved `jax>=0.7` stack (autoconf[jax]). The nightly restores
+    # compatibility. Durable fix (vendor bessel_kve, drop tfp) tracked separately.
+    "tfp-nightly==0.26.0.dev20260713"
 ]
 test = ["pytest"]
 dev = ["pytest", "black", "numba", "nufftax>=0.4.0,<0.5.0; python_version >= '3.12'", "pynufft==2022.2.2"]


### PR DESCRIPTION
## Summary
The JAX Matern-kernel regularization path crashed at import for every user on the release-resolved stack. `autoarray/inversion/regularization/matern_kernel.py` (`kv_xp`) imports `tensorflow_probability.substrates.jax` for `bessel_kve`; the last **stable** tfp (0.25.0) references `jax.interpreters.xla.pytype_aval_mappings`, removed from modern JAX, so `import` crashes under `jax 0.10.2`. Surfaced by release-validation run `29266305445` (TestPyPI `2026.7.13.1.dev65501`).

## Fix
- `pyproject.toml` (`optional` extra): `tensorflow-probability==0.25.0` → `tfp-nightly==0.26.0.dev20260713`. No stable tfp is compatible (0.25.0 is the latest); the nightly restores modern-JAX support and installs via an explicit `==` pin (no `--pre`). Import name is unchanged, so `matern_kernel.py` needs no code edit.
- `matern_kernel.py`: corrected the `kv_xp` docstring (it advertised a non-existent `jax.scipy.special.kv` fast-path) and pointed the `ImportError` at `tfp-nightly`. No behaviour change.

## Why not the alternatives
- **Lower the jax cap** — infeasible; `pytype_aval_mappings` is gone by jax 0.9.2 and `autoconf[jax]` floors `jax>=0.7`.
- **Drop tfp / use jax.scipy** — `jax.scipy.special` has no `kv`/`kve`, and `nu` is a continuous free prior, so no closed-form shortcut. Vendoring tfp's `bessel_kve` is the durable fix, filed as a follow-up.

## Verification
- Reproduced the crash clean-env (`jax 0.10.2` + `tfp 0.25.0`); confirmed `tfp-nightly` computes `bessel_kve(0.5,1.0)=1.2533` on `jax 0.10.2`.
- New parity assertion (in the paired `autogalaxy_workspace_test` PR): np-vs-JAX Matern regularization matrix at `nu=0.5` and `nu=1.7`, jitted → passes.
- `pytest test_autoarray/` → **897 passed**.

## API Changes
None — public surface unchanged.

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDCsgNCXacXqiWAPTswWCt
