### PR TITLE
fix: test-mode-gate singular/non-PD inversion crash (release tail)

### DIFF
--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 from typing import Dict, List, Optional, Type, Union
 
-from autoconf import cached_property
+from autoconf import cached_property, is_test_mode
 
 from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.dataset.interferometer.dataset import Interferometer
@@ -712,13 +712,23 @@ class AbstractInversion:
         if not self.has(cls=AbstractRegularization):
             return 0.0
 
-        return 2.0 * self._xp.sum(
-            self._xp.log(
-                self._xp.diag(
-                    self._xp.linalg.cholesky(self.curvature_reg_matrix_reduced)
+        try:
+            return 2.0 * self._xp.sum(
+                self._xp.log(
+                    self._xp.diag(
+                        self._xp.linalg.cholesky(self.curvature_reg_matrix_reduced)
+                    )
                 )
             )
-        )
+        except np.linalg.LinAlgError:
+            if is_test_mode():
+                # Singular curvature-reg matrix from a fabricated test-mode model;
+                # this evidence term is discarded. Return a benign 0.0 so unguarded
+                # test-mode paths do not crash (matches the reconstruction guard in
+                # inversion_util). Normal runs re-raise unchanged. numpy-only: the
+                # JAX cholesky returns NaN rather than raising.
+                return 0.0
+            raise
 
     @property
     def log_det_regularization_matrix_term(self) -> float:
@@ -737,13 +747,21 @@ class AbstractInversion:
         if not self.has(cls=AbstractRegularization):
             return 0.0
 
-        return 2.0 * self._xp.sum(
-            self._xp.log(
-                self._xp.diag(
-                    self._xp.linalg.cholesky(self.regularization_matrix_reduced)
+        try:
+            return 2.0 * self._xp.sum(
+                self._xp.log(
+                    self._xp.diag(
+                        self._xp.linalg.cholesky(self.regularization_matrix_reduced)
+                    )
                 )
             )
-        )
+        except np.linalg.LinAlgError:
+            if is_test_mode():
+                # Singular regularization matrix from a fabricated test-mode model;
+                # this evidence term is discarded. Benign 0.0 in test mode, unchanged
+                # (raise) in normal operation. numpy-only (JAX cholesky returns NaN).
+                return 0.0
+            raise
 
     @property
     def reconstruction_noise_map_with_covariance(self) -> np.ndarray:

--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from typing import List, Optional, Type
 
+from autoconf import is_test_mode
+
 from autoarray.settings import Settings
 
 from autoarray import exc
@@ -221,7 +223,19 @@ def reconstruction_positive_negative_from(
     curvature_reg_matrix
         The curvature_matrix plus regularization matrix, overwriting the curvature_matrix in memory.
     """
-    return xp.linalg.solve(curvature_reg_matrix, data_vector)
+    try:
+        return xp.linalg.solve(curvature_reg_matrix, data_vector)
+    except np.linalg.LinAlgError:
+        if is_test_mode():
+            # Test-mode fits run fabricated / under-converged models whose
+            # curvature-regularization matrix can be singular; the reconstruction
+            # value is discarded. Return a benign dummy so unguarded test-mode
+            # paths (search chaining, preloads, result construction) do not crash.
+            # Normal runs re-raise unchanged and resample via the likelihood's
+            # FitException guard — real-mode numerics are untouched. (The JAX path
+            # returns NaN rather than raising, so this branch is numpy-only.)
+            return xp.ones_like(data_vector)
+        raise
 
 
 def reconstruction_positive_only_from(
@@ -350,6 +364,10 @@ def reconstruction_positive_only_from(
         )
 
     except (RuntimeError, np.linalg.LinAlgError, ValueError) as e:
+        if is_test_mode():
+            # See reconstruction_positive_negative_from: benign dummy in test mode,
+            # unchanged (raise InversionException) in normal operation.
+            return xp.ones_like(data_vector)
         raise exc.InversionException() from e
 
 

--- a/test_autoarray/inversion/inversion/test_inversion_util.py
+++ b/test_autoarray/inversion/inversion/test_inversion_util.py
@@ -228,3 +228,56 @@ def test__preconditioner_matrix_via_mapping_matrix_from():
         preconditioner_matrix
         == np.array([[5.0, 2.0, 3.0], [4.0, 9.0, 6.0], [7.0, 8.0, 13.0]])
     ).all()
+
+
+def test__reconstruction_positive_negative_from__singular_matrix_test_mode_returns_dummy(
+    monkeypatch,
+):
+    # A rank-deficient curvature-regularization matrix makes np.linalg.solve
+    # raise a singular-matrix LinAlgError.
+    curvature_reg_matrix = np.array([[1.0, 1.0], [1.0, 1.0]])
+    data_vector = np.array([1.0, 2.0])
+
+    # Normal operation: the singular solve raises, so the search resamples.
+    monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+    with pytest.raises(np.linalg.LinAlgError):
+        aa.util.inversion.reconstruction_positive_negative_from(
+            data_vector=data_vector,
+            curvature_reg_matrix=curvature_reg_matrix,
+        )
+
+    # Test mode: the fabricated model's reconstruction is discarded, so a benign
+    # finite dummy is returned instead of crashing an unguarded test-mode path.
+    monkeypatch.setenv("PYAUTO_TEST_MODE", "1")
+    reconstruction = aa.util.inversion.reconstruction_positive_negative_from(
+        data_vector=data_vector,
+        curvature_reg_matrix=curvature_reg_matrix,
+    )
+    assert reconstruction.shape == data_vector.shape
+    assert np.all(np.isfinite(reconstruction))
+    assert (reconstruction == 1.0).all()
+
+
+def test__reconstruction_positive_only_from__singular_matrix_test_mode_returns_dummy(
+    monkeypatch,
+):
+    curvature_reg_matrix = np.array([[1.0, 1.0], [1.0, 1.0]])
+    data_vector = np.array([1.0, 2.0])
+
+    # Normal operation: the singular solve raises InversionException (resample).
+    monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+    with pytest.raises(aa.exc.InversionException):
+        aa.util.inversion.reconstruction_positive_only_from(
+            data_vector=data_vector,
+            curvature_reg_matrix=curvature_reg_matrix,
+        )
+
+    # Test mode: benign finite dummy instead of crashing.
+    monkeypatch.setenv("PYAUTO_TEST_MODE", "1")
+    reconstruction = aa.util.inversion.reconstruction_positive_only_from(
+        data_vector=data_vector,
+        curvature_reg_matrix=curvature_reg_matrix,
+    )
+    assert reconstruction.shape == data_vector.shape
+    assert np.all(np.isfinite(reconstruction))
+    assert (reconstruction == 1.0).all()


### PR DESCRIPTION
Closes part of PyAutoArray#388.

## Summary

Return a benign dummy from the inversion reconstruction / log-det sites **only** when `autoconf.is_test_mode()` is active, instead of raising on a singular/non-PD curvature-regularization matrix. In test mode the fitted model is fabricated / under-converged and the inversion output is discarded, so an unguarded test-mode path (search chaining, preloads, result construction) should not crash — while the real likelihood path already resamples such solutions via `FitException`.

Normal operation is **byte-for-byte unchanged**: all four sites re-raise exactly as before (`LinAlgError` / `InversionException`), so real-mode numerics and search resample behaviour are untouched. numpy-only by construction (the JAX linalg path returns NaN rather than raising). **No conditioning floor** — nothing perturbs real evidences/reconstructions.

Sites gated on `is_test_mode()`:
- `inversion_util.reconstruction_positive_negative_from` (`xp.linalg.solve`)
- `inversion_util.reconstruction_positive_only_from` (fnnls `except`)
- `abstract.log_det_curvature_reg_matrix_term` (cholesky)
- `abstract.log_det_regularization_matrix_term` (cholesky)

## Corrective-PR exception (Heart RED)

Opened under the human-authorized corrective-PR exception (`AUTONOMY.md`), authorized in-session 2026-07-14.

- **Named RED reason:** `release validation FAILED (stage integrate)`
- **Causal map:** integrate stage FAILed on `interferometer/.../multi_gaussian_expansion/slam.py` + `imaging/features/pixelization/cpu_fast_modeling.py` (run 29341418859) → both crash on an unguarded singular inversion in test-mode chained paths → 4-site `is_test_mode()` dummy guard → this PR. Follow-up to PyAutoLens#607, which guarded the real/likelihood path but not these test-mode paths.
- **Scope:** this one pending-release PR only; no merge, issue close, release, or rehearsal in this action. Merge is a separate human act.
- **Sibling RED reason remains:** `PyAutoArray: on branch feature/ticks-minus-in-math (not main)` — Heart stays RED until that is also resolved and integrate validation re-runs.

## Caveat on causal strength

Unlike #607 (deterministic repro), these two FAILs **did not reproduce on clean `main`** (TEST_MODE=1 and =2 both pass; the crash is flaky/non-deterministic). This is a test-mode-gated dummy, not a real-path correctness change. It plausibly removes the FAILs; confirmation comes only from the post-merge fresh-wheels re-validation of the integrate stage.

## Validation checklist

- [x] New numpy-only unit tests: singular matrix raises normally; under monkeypatched `PYAUTO_TEST_MODE` returns finite dummies.
- [x] `test_autoarray/inversion/inversion/` (util + abstract): 41 passed.
- [x] Full `test_autoarray/inversion/`: 233 passed.
- [x] No JAX in unit tests (per repo rule); JAX path covered by `*_workspace_test` parity scripts.
- [ ] Post-merge: fresh wheels + re-run release integration on `main` + new Heart verdict (required before any release decision).

Self-review: CLEAN — commit `48fae1ac`, 3 files (+101/−12), no mixed scope.