### PR TITLE
fix(convolver): build from_gaussian kernel at full size under PYAUTO_SMALL_DATASETS

### DIFF
--- a/autoarray/operators/convolver.py
+++ b/autoarray/operators/convolver.py
@@ -699,7 +699,10 @@ class Convolver:
         Parameters
         ----------
         shape_native
-            The 2D shape of the mask the array is paired with.
+            The 2D shape of the mask the array is paired with. The kernel is always built at this
+            size, including when ``PYAUTO_SMALL_DATASETS=1`` is set — a kernel's shape is intrinsic
+            to the convolution operator, not a dataset size, so the fast-mode dataset cap does not
+            apply to it.
         pixel_scales
             The (y,x) arcsecond-to-pixel units conversion factor of every pixel. If this is input as a `float`,
             it is converted to a (float, float).
@@ -718,7 +721,13 @@ class Convolver:
             ``pixel_scales`` input should be the fine resolution (image pixel scale divided by this size).
         """
 
-        grid = Grid2D.uniform(shape_native=shape_native, pixel_scales=pixel_scales)
+        grid = Grid2D.uniform(
+            shape_native=shape_native,
+            pixel_scales=pixel_scales,
+            # The kernel is wrapped in an `Array2D` at `shape_native` below, so letting the
+            # `PYAUTO_SMALL_DATASETS` cap shrink this grid would leave the two inconsistent.
+            respect_small_datasets=False,
+        )
         grid_shifted = np.subtract(grid.array, centre)
         grid_radius = np.sqrt(np.sum(grid_shifted**2.0, 1))
         theta_coordinate_to_profile = np.arctan2(

--- a/test_autoarray/operators/test_convolver.py
+++ b/test_autoarray/operators/test_convolver.py
@@ -53,6 +53,30 @@ def test__from_gaussian__normalized__kernel_values_match_expected():
     )
 
 
+def test__from_gaussian__small_datasets__kernel_keeps_full_requested_shape(monkeypatch):
+    """
+    The `PYAUTO_SMALL_DATASETS` fast-mode cap shrinks datasets (and the grids paired with
+    them) to 16x16, but a convolution kernel's shape is intrinsic to the operator. If the
+    cap reached the grid the Gaussian is evaluated on, its 256 values would be wrapped in an
+    `Array2D` at the uncapped `shape_native` of 961, raising an `ArrayException`.
+    """
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    convolver = aa.Convolver.from_gaussian(
+        shape_native=(31, 31),
+        pixel_scales=0.1,
+        sigma=0.1,
+    )
+
+    assert convolver.kernel.shape_native == (31, 31)
+
+    image = aa.Array2D.ones(shape_native=(16, 16), pixel_scales=0.1)
+
+    blurred_image = convolver.convolved_image_from(image=image, blurring_image=None)
+
+    assert blurred_image.shape_native == (16, 16)
+
+
 def test__normalize__ones_kernel__each_element_equals_one_ninth():
 
     kernel_data = aa.Array2D.ones(shape_native=(3, 3), pixel_scales=1.0)


### PR DESCRIPTION
## Summary

`Convolver.from_gaussian` raised `ArrayException` for any kernel larger than 16x16 when
`PYAUTO_SMALL_DATASETS=1` (the smoke/fast-mode dataset cap).

It evaluates its Gaussian on a `Grid2D.uniform`, which the cap silently shrinks to
(16, 16), then wraps the resulting 256 values in an `Array2D` at the caller's *uncapped*
`shape_native` — a self-inconsistent construction:

```
ArrayException: array_2d_slim.shape = 256  vs  mask_2d.pixels_in_mask = 961, shape_native (31, 31)
```

A convolution kernel's shape is intrinsic to the operator, not a dataset size (a 31x31
kernel convolving a 16x16 image is perfectly valid), so the dataset cap must not reach it.
Fixed by passing the existing `Grid2D.uniform(respect_small_datasets=False)` opt-out.

This unblocks `scripts/imaging/data_preparation/manual/mask_irregular.py` in both
autolens_workspace and autogalaxy_workspace, which were failing in fast-mode runs.
No workspace changes are needed. Closes #397.

## API Changes

None — internal changes only. Behaviour changes only under `PYAUTO_SMALL_DATASETS=1`,
a smoke-test-only flag never set in normal use: kernels above 16x16 now build correctly
instead of raising. Full-resolution behaviour is byte-identical.
See full details below.

## Test Plan
- [x] New regression test `test__from_gaussian__small_datasets__kernel_keeps_full_requested_shape`
      — fails on `main` with the exact production `ArrayException`, passes with the fix
- [x] Full PyAutoArray suite: **927 passed**
- [x] `mask_irregular.py` runs clean under the smoke env in autolens_workspace + autogalaxy_workspace
- [x] Same scripts with `PYAUTO_SMALL_DATASETS` unset still pass (full-res path untouched)
- [x] 11x11 consumer `autolens_workspace/scripts/imaging/simulator.py` unchanged under smoke env

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autoarray.Convolver.from_gaussian(shape_native=...)` — the kernel grid no longer honours
  the `PYAUTO_SMALL_DATASETS` cap. Previously, with the env var set, `shape_native` above
  16x16 raised `ArrayException`; it now builds the kernel at the full requested size.
  Unaffected when the env var is unset, and for kernels at or below 16x16.

### Migration
None required.

</details>

Generated by the PyAutoLabs agent workflow.