### PR TITLE
docs: drop the grids.yaml bullet from the config README

### DIFF
--- a/autoarray/config/README.md
+++ b/autoarray/config/README.md
@@ -8,6 +8,5 @@ The `config` folder contains configuration files which customize default **PyAut
 # Files
 
 - `general.yaml`: Customizes general **PyAutoLens** settings.
-- `grids.yaml`: Customize default behaviour of grids when used for calculations.
 - `logging.yaml`: Customizes the logging behaviour.
 - `notation.yaml`: Configs defining labels and formatting of model parameters when used for visualization.


### PR DESCRIPTION
## Summary

Removes the `grids.yaml` bullet from this repo's `config/README.md`. The README listed `grids.yaml` among the files in that directory, but the directory has not contained one since the `radial_minimum` consumer was removed in PyAutoGalaxy `025ac7ac` (2025-10-15) — the README has been documenting a file that isn't there.

Docs only. No config file is deleted in this repo, because this repo already ships none. The ten surviving downstream copies are deleted in the same sweep.

## Scripts Changed

None — docs only.

- `config/README.md` — dropped the `grids.yaml` bullet (line 11)

## Test Plan

- [x] The `config/` directory contains no `grids.yaml`, so the README now matches reality
- [x] Grep sweep for `grids.yaml` / `radial_minimum` across the repo: zero hits

Closes part of PyAutoLabs/autolens_workspace#317.

Generated by the PyAutoLabs agent workflow.