### PR TITLE
feat: require Python 3.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest t
 
 PRs must pass `pytest --cov` on the CI matrix (Python 3.12 **and** 3.13). There
 is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
-`pyproject.toml` is `>=3.9`.)
+`pyproject.toml` is `>=3.12`.)
 
 ## Configuration & defaults
 

--- a/autoarray/operators/transformer.py
+++ b/autoarray/operators/transformer.py
@@ -1,6 +1,5 @@
 import copy
 import numpy as np
-import sys
 import warnings
 from typing import Optional, Tuple
 
@@ -42,32 +41,6 @@ def pynufft_exception():
 
 
 def nufftax_exception():
-    # On Python 3.11 `pip install nufftax` is actively bad advice. The releases
-    # that work with our JAX stack (0.4.x) require Python >= 3.12, so pip resolves
-    # 0.6.x instead — and 0.6.0/0.6.1 both break the interferometer inversion
-    # (0.6.0 uses `jax.interpreters.batching.not_mapped`, removed in JAX 0.10;
-    # 0.6.1 cannot handle the rank-4 input `transform_mapping_matrix` produces
-    # under vmap). There is currently no nufftax release that both installs on
-    # 3.11 and works, so send 3.11 users to 3.12+ or to the pynufft backend.
-    if sys.version_info < (3, 12):
-        raise ModuleNotFoundError(
-            "\n--------------------\n"
-            "You are attempting to perform interferometer analysis with the default "
-            f"JAX-native `TransformerNUFFT`, on Python {sys.version_info.major}.{sys.version_info.minor}.\n\n"
-            "The optional library nufftax (https://github.com/GragasLab/nufftax) is not installed, "
-            "and on this Python version it CANNOT be usefully installed:\n\n"
-            "  - nufftax releases that work with PyAutoArray require Python >= 3.12.\n"
-            "  - The releases that do install here (0.6.x) are incompatible with the "
-            "JAX version PyAutoArray requires, and fail partway through a fit.\n\n"
-            "Do NOT `pip install nufftax` on this Python version. Instead either:\n\n"
-            "  1. Upgrade to Python 3.12 or newer (recommended), then "
-            "`pip install 'autoarray[optional]'`; or\n"
-            "  2. Use the legacy pynufft backend, by passing "
-            "`transformer_class=TransformerNUFFTPyNUFFT` and running "
-            "`pip install pynufft==2022.2.2`.\n\n"
-            "----------------------"
-        )
-
     raise ModuleNotFoundError(
         "\n--------------------\n"
         "You are attempting to perform interferometer analysis with the default "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
   description="PyAuto Data Structures"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Hayes", email = "richard@rghsoftware.co.uk" },
@@ -18,9 +18,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
@@ -56,7 +53,7 @@ jax = ["autonerves[jax]"]
 optional = [
     "autoarray[jax]",
     "numba",
-    "nufftax>=0.4.0,<0.5.0; python_version >= '3.12'",
+    "nufftax>=0.4.0,<0.5.0",
     "pynufft",
     # tfp provides the modified-Bessel `bessel_kve` used by the JAX Matern-kernel
     # regularization path (autoarray/inversion/regularization/matern_kernel.py).
@@ -67,7 +64,7 @@ optional = [
     "tfp-nightly==0.26.0.dev20260713"
 ]
 test = ["pytest"]
-dev = ["pytest", "black", "numba", "nufftax>=0.4.0,<0.5.0; python_version >= '3.12'", "pynufft==2022.2.2"]
+dev = ["pytest", "black", "numba", "nufftax>=0.4.0,<0.5.0", "pynufft==2022.2.2"]
 
 [tool.pytest.ini_options]
 testpaths = ["test_autoarray"]

--- a/test_autoarray/conftest.py
+++ b/test_autoarray/conftest.py
@@ -287,13 +287,11 @@ def pytest_collection_modifyitems(config, items):
     it is not installed.
 
     The default ``Interferometer`` transformer is the JAX-native
-    ``TransformerNUFFT``, backed by ``nufftax`` — which is declared for Python
-    ``>= 3.12`` only (Python 3.9-3.11 are not officially supported). On those
-    interpreters the backend cannot be installed, so any test that builds a
-    default interferometer/transformer raises ``ModuleNotFoundError`` at
-    construction. Skip exactly those, while keeping the explicit ``DFT`` and
-    ``pynufft`` transformer tests, which have no ``nufftax`` dependency. On
-    3.12/3.13 (where ``nufftax`` is present) nothing is skipped.
+    ``TransformerNUFFT``, backed by the optional ``nufftax`` dependency. When
+    that backend is absent, any test that builds a default interferometer or
+    transformer raises ``ModuleNotFoundError`` at construction. Skip exactly
+    those tests while keeping the explicit ``DFT`` and ``pynufft`` transformer
+    tests, which have no ``nufftax`` dependency.
     """
     try:
         import nufftax  # noqa: F401
@@ -303,7 +301,7 @@ def pytest_collection_modifyitems(config, items):
         pass
 
     skip_nufftax = pytest.mark.skip(
-        reason="nufftax (default JAX interferometer backend) requires Python >= 3.12"
+        reason="nufftax (the default JAX interferometer backend) is not installed"
     )
     for item in items:
         name = item.nodeid.rsplit("::", 1)[-1]

--- a/test_autoarray/operators/test_transformer.py
+++ b/test_autoarray/operators/test_transformer.py
@@ -308,47 +308,11 @@ def test__nufft__chunk_size__jax_jit_traces_with_scan():
     )
 
 
-def test__nufftax_exception__pre_3_12_tells_user_to_upgrade_not_to_pip_install():
-    """
-    On Python < 3.12 there is no usable nufftax release: the versions that work
-    require >= 3.12, and the ones that do install (0.6.x) break mid-fit. The
-    error must therefore steer the user away from `pip install nufftax`.
-    """
-    import collections
-    from unittest import mock
+def test__nufftax_exception__keeps_the_plain_install_instruction():
     from autoarray.operators import transformer
 
-    version_info = collections.namedtuple(
-        "version_info", "major minor micro releaselevel serial"
-    )
-
-    with mock.patch.object(
-        transformer.sys, "version_info", version_info(3, 11, 0, "final", 0)
-    ):
-        with pytest.raises(ModuleNotFoundError) as exc:
-            transformer.nufftax_exception()
-
-    message = str(exc.value)
-    assert "Python 3.11" in message
-    assert "Do NOT `pip install nufftax`" in message
-    assert "Python 3.12 or newer" in message
-    assert "TransformerNUFFTPyNUFFT" in message
-
-
-def test__nufftax_exception__3_12_and_later_keeps_the_plain_install_instruction():
-    import collections
-    from unittest import mock
-    from autoarray.operators import transformer
-
-    version_info = collections.namedtuple(
-        "version_info", "major minor micro releaselevel serial"
-    )
-
-    with mock.patch.object(
-        transformer.sys, "version_info", version_info(3, 12, 0, "final", 0)
-    ):
-        with pytest.raises(ModuleNotFoundError) as exc:
-            transformer.nufftax_exception()
+    with pytest.raises(ModuleNotFoundError) as exc:
+        transformer.nufftax_exception()
 
     message = str(exc.value)
     assert "Install it via the command `pip install nufftax`" in message


### PR DESCRIPTION
## Summary
Raise PyAutoArray's minimum supported Python version to 3.12 and advertise only Python 3.12 and 3.13.

Remove Python-version markers that became tautological while preserving the supported nufftax range, and delete the now-unreachable pre-3.12 nufftax error path and test.

Refs #418.

## API Changes
Python API symbols and signatures are unchanged. Installation now requires Python 3.12 or newer, and the missing-nufftax error path is simplified for supported runtimes.
See full details below.

## Test Plan
- [x] Python 3.12: 929 passed
- [x] Python 3.13 official profile: 928 passed, 1 skipped
- [x] Wheel metadata: Requires-Python >=3.12; classifiers 3.12/3.13 only; nufftax >=0.4,<0.5 preserved without Python markers
- [x] Curated ecosystem smoke: 50 passed, 12 parallel timeouts, 3 intentional skips; sequential retry passed 11/12, with the known 300-second subhalo_recovery.py timeout explicitly accepted by the human as non-causal
- [x] Independent Claude Opus 5 review: CLEAN
- [x] Heart: YELLOW score 65, exact previously acknowledged campaign reason set, no RED

## Validation checklist (--auto run — plan was not pre-approved)
- Effective level: safe (header: supervised, cap: feature medium → safe)
- Plan: on issue #418, written at start, unmodified since
- Gate: tests 3.12 929 passed + 3.13 928 passed/1 skipped · smoke accepted non-causal single timeout after 11/12 sequential retries passed · review CLEAN · Heart YELLOW within launch acknowledgement
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [x] Human: merge authorized contingent on exact reviewed head and green CI

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- Package installation now requires Python 3.12 or newer.
- autoarray.operators.transformer.nufftax_exception() always emits the supported-runtime installation guidance; its special Python 3.9–3.11 message is removed.

### Migration
- Recreate environments on Python 3.12 or newer before installing the next PyAutoArray release.

</details>

Generated by the PyAutoLabs agent workflow.
