### PR TITLE
docs: retarget xp=np guard ValueError pointer to using_jax.py

### DIFF
--- a/autoarray/structures/decorators/abstract.py
+++ b/autoarray/structures/decorators/abstract.py
@@ -54,8 +54,8 @@ class AbstractMaker:
                 f"Called {getattr(func, '__qualname__', repr(func))} with "
                 f"xp=np but the input grid is JAX-backed (grid.use_jax=True). "
                 f"Inside @jax.jit, pass xp=jnp explicitly to the library call. "
-                f"See the autolens_workspace `scripts/guides/lens_calc.py` "
-                f"`__JAX__` section (Phase 5d) for the JIT-it-yourself pattern."
+                f"See the autolens_workspace `scripts/guides/using_jax.py` "
+                f"guide for the JIT-it-yourself pattern."
             )
 
         self.func = func


### PR DESCRIPTION
## Summary
The JAX pairing-rule guard's `ValueError` pointed users at the autolens_workspace `scripts/guides/lens_calc.py` `__JAX__` section "(Phase 5d)" — deleted by autolens_workspace#415 (the JIT-it-yourself pattern now lives in the runnable, smoke-tested `scripts/guides/using_jax.py`). This retargets the message's final sentence and drops the internal-phase reference. Two-line message change; no behaviour change.

Sibling sweep pre-verified: `grep -rn "Phase 5d\|lens_calc"` across PyAutoArray now returns zero hits.

## API Changes
None — error-message text only. `test_abstract_xp_mismatch.py` asserts only the message's first sentence and passes (3/3).

## Test Plan
- [x] `pytest test_autoarray/structures/decorators/test_abstract_xp_mismatch.py` — 3 passed
- [ ] CI passes

Closes #427.

Generated by the PyAutoLabs agent workflow.