### PR TITLE
fix: relabel at-or-below-cap data at the capped pixel scale

### DIFF
--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -10,18 +10,30 @@ SMALL_DATASETS_PIXEL_SCALES = 0.6
 def cap_array_2d_for_small_datasets(array_2d, pixel_scales):
     """
     Center-crop a 2D autoarray to the small-datasets cap when
-    ``PYAUTO_SMALL_DATASETS=1`` is active.
+    ``PYAUTO_SMALL_DATASETS=1`` is active, and relabel it at the capped
+    pixel scale.
 
-    Returns ``(array_2d, pixel_scales)`` unchanged in any of these cases:
+    Returns ``(array_2d, pixel_scales)`` unchanged only when
+    ``PYAUTO_SMALL_DATASETS`` is not set to ``"1"``.
 
-    - ``PYAUTO_SMALL_DATASETS`` is not set to ``"1"``.
-    - ``array_2d.shape_native`` is already at-or-below the cap (16, 16).
+    When the env var is set, ``pixel_scales`` is always overridden to 0.6 —
+    matching the convention used by ``Mask2D.circular`` and ``Grid2D.uniform``
+    so the loaded dataset stays shape-consistent with masks and grids built
+    under the same env var — and the shape is handled per case:
 
-    When the env var is set and the input shape exceeds (16, 16), returns a
-    new ``Array2D`` center-cropped to (16, 16) with ``pixel_scales`` overridden
-    to 0.6 — matching the convention used by ``Mask2D.circular`` and
-    ``Grid2D.uniform`` so the loaded dataset stays shape-consistent with masks
-    and grids built under the same env var.
+    - Input shape exceeds (16, 16): center-cropped to (16, 16).
+    - Input shape is already at-or-below the cap: kept as-is, because a capped
+      simulator wrote it at 0.6 already. Only the scale is corrected.
+
+    That second case must still rebuild the ``Array2D``, not just return a
+    corrected scalar: the array is constructed by the caller before this call
+    and carries its own geometry, so an uncorrected array would keep the
+    caller's uncapped scale no matter what scalar is returned. Leaving it
+    uncorrected mislabels the frame 6x (±0.8" instead of ±4.8" for a 16x16
+    field), which pushes off-centre galaxies outside the frame; their
+    non-negative linear intensity solve then correctly returns exactly 0.0 and
+    the failure surfaces far downstream as a collapsed prior rather than as a
+    geometry error (PyAutoArray #430).
 
     The same env var is honoured for shape construction in
     ``Mask2D.circular`` and ``Grid2D.uniform`` (and by ``should_simulate``
@@ -36,12 +48,18 @@ def cap_array_2d_for_small_datasets(array_2d, pixel_scales):
     if os.environ.get("PYAUTO_SMALL_DATASETS") != "1":
         return array_2d, pixel_scales
 
+    from autoarray.structures.arrays.uniform_2d import Array2D
+
     h, w = array_2d.shape_native
     cap_h, cap_w = SMALL_DATASETS_SHAPE_NATIVE
     if h <= cap_h and w <= cap_w:
-        return array_2d, pixel_scales
-
-    from autoarray.structures.arrays.uniform_2d import Array2D
+        return (
+            Array2D.no_mask(
+                values=array_2d.native.array,
+                pixel_scales=SMALL_DATASETS_PIXEL_SCALES,
+            ),
+            SMALL_DATASETS_PIXEL_SCALES,
+        )
 
     h0, w0 = (h - cap_h) // 2, (w - cap_w) // 2
     cropped = array_2d.native.array[h0:h0 + cap_h, w0:w0 + cap_w]

--- a/test_autoarray/util/test_dataset_util.py
+++ b/test_autoarray/util/test_dataset_util.py
@@ -25,24 +25,41 @@ def test__env_unset__returns_inputs_unchanged(monkeypatch):
     assert pixel_scales == 0.08
 
 
-def test__env_set__shape_already_at_cap__returns_inputs_unchanged(monkeypatch):
+def test__env_set__shape_already_at_cap__relabels_pixel_scales_without_cropping(
+    monkeypatch,
+):
     monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
 
     array = _array_2d(SMALL_DATASETS_SHAPE_NATIVE, pixel_scales=0.08)
     result, pixel_scales = cap_array_2d_for_small_datasets(array, 0.08)
 
-    assert result is array
-    assert pixel_scales == 0.08
+    assert result is not array
+    assert result.shape_native == SMALL_DATASETS_SHAPE_NATIVE
+    assert pixel_scales == SMALL_DATASETS_PIXEL_SCALES
+    assert result.pixel_scales == (
+        SMALL_DATASETS_PIXEL_SCALES,
+        SMALL_DATASETS_PIXEL_SCALES,
+    )
+    assert (result.native.array == array.native.array).all()
 
 
-def test__env_set__shape_below_cap__returns_inputs_unchanged(monkeypatch):
+def test__env_set__shape_below_cap__relabels_pixel_scales_without_cropping(monkeypatch):
     monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
 
-    array = _array_2d((10, 10), pixel_scales=0.08)
+    raw = np.arange(10 * 10, dtype=float).reshape(10, 10)
+    array = aa.Array2D.no_mask(values=raw, pixel_scales=0.08)
+
     result, pixel_scales = cap_array_2d_for_small_datasets(array, 0.08)
 
-    assert result is array
-    assert pixel_scales == 0.08
+    assert result is not array
+    # Shape is PRESERVED — the below-cap branch relabels, it must never crop.
+    assert result.shape_native == (10, 10)
+    assert pixel_scales == SMALL_DATASETS_PIXEL_SCALES
+    assert result.pixel_scales == (
+        SMALL_DATASETS_PIXEL_SCALES,
+        SMALL_DATASETS_PIXEL_SCALES,
+    )
+    assert (result.native.array == raw).all()
 
 
 def test__env_set__shape_above_cap__center_crops_and_overrides_pixel_scales(


### PR DESCRIPTION
## Summary

`cap_array_2d_for_small_datasets` handled one case and silently dropped the other. Data *larger* than the 16x16 `PYAUTO_SMALL_DATASETS` cap was cropped **and** rebuilt at `SMALL_DATASETS_PIXEL_SCALES` (0.6); data already at-or-below the cap early-returned, keeping the caller's uncapped `pixel_scales` (0.1). A capped simulator writes its data at 0.6, so the loader mislabelled the frame 6x — ±0.8" instead of ±4.8" for a 16x16 field.

Off-centre galaxies then fell outside the mislabelled frame, their non-negative linear intensity solve correctly returned exactly 0.0, `total_luminosity` became 0, and `min(5 * 0.5 * 0**0.6, 5.0)` collapsed a `UniformPrior` to `lower == upper == 0.0`. The `PriorException` surfaced four steps downstream in `autolens_workspace/scripts/group/slam.py:321`, naming neither the loader nor the pixel scale.

The at-or-below-cap branch now rebuilds the `Array2D` at the capped scale, mirroring the crop branch. Shape is preserved — that branch must never crop. Rebuilding is required rather than returning a corrected scalar: the `Array2D` is constructed by the caller before the call and carries its own geometry.

Fixes #430. Fixes the `group/slam.py` + `group/slam.ipynb` failures in PyAutoHeart Workspace Smoke run 30790463134.

## API Changes

No signature changes. One behaviour change, confined to runs with `PYAUTO_SMALL_DATASETS=1`:
`autoarray.util.dataset_util.cap_array_2d_for_small_datasets` now returns `SMALL_DATASETS_PIXEL_SCALES` (0.6) and a rebuilt `Array2D` for input already at-or-below the cap, where it previously returned the caller's `pixel_scales` and the input array untouched. Shape is unchanged in that branch. Reached in practice through `Imaging.from_fits`, which routes `data` and `noise_map` (not `psf`) through it.

With the cap unset — every normal run — behaviour is byte-identical, and the crop branch is untouched.

See full details below.

## Test Plan

- [x] `pytest test_autoarray/` — 929 passed
- [x] `scripts/group/slam.py` (autolens_workspace) under the capped smoke profile, cleared dataset + output → exit 0, all six SLaM stages genuinely run (0 cached resumes; note output is namespaced under `output/test_mode/`)
- [x] Crop path unchanged — 209x209 `cosmos_web_ring` gives `(16,16) @ 0.6` identically before and after
- [x] Normal uncapped operation unaffected — `scripts/imaging/start_here.py` (`ENV: full_datasets`) exit 0
- [x] Committed datasets audited: of 31 committed dataset FITS, exactly one is at-or-below the cap (`slacs1430+4105/psf.fits`, 11x11) and PSFs never route through the capper — so no committed dataset changes scale

### Downstream effect on two parked scripts

- `imaging/features/scaling_relation/slam` → now exit 0 (6 real searches). Its `NEEDS_FIX` park in `autolens_workspace/config/build/no_run.yaml` can be removed in a separate workspace PR.
- `multi_galaxy/features/scaling_relation/slam` → gets past the 0.0-luminosity cause (real luminosities now measured) but then hits a **separate latent script bug**: `slam.py:863` computes `image_half_width` from the script's own hardcoded `pixel_scale` (0.1) while the mask is built from `dataset_full.pixel_scales` (now correctly 0.6), producing an empty mask. Not a regression — on unpatched `main` it fails earlier with the documented 0.0-luminosity error. Stays parked; filed separately.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autoarray.util.dataset_util.cap_array_2d_for_small_datasets(array_2d, pixel_scales)` — when `PYAUTO_SMALL_DATASETS=1` and `array_2d.shape_native` is at-or-below `SMALL_DATASETS_SHAPE_NATIVE`, now returns a rebuilt `Array2D` at `SMALL_DATASETS_PIXEL_SCALES` and that scale, instead of returning the inputs unchanged. Shape preserved; no cropping in this branch. Unchanged when the env var is unset, and unchanged for above-cap input.

### Removed
- None

### Added
- None

### Migration
- None required. Callers that already consume the returned `pixel_scales` (the documented contract, and what `Imaging.from_fits` does) need no change. Code that ignored the returned `pixel_scales` and reused its own literal was already relying on the buggy path under the cap; it should consume the returned value or read `dataset.pixel_scales`.

</details>

Generated by the PyAutoLabs agent workflow.
