### PR TITLE
fix: drop stale astropy <=7.2.0 cap (floors, not pins)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     # "version X does not provide the extra 'jax'" is a pip *warning*, not an
     # error, so a pre-extras release is a legal solution. PyAutoLens#687.
     "autonerves>=2026.7.29.2",
-    "astropy>=5.0,<=7.2.0",
+    "astropy>=5.0",
     "decorator>=4.0.0",
     "dill>=0.3.1.1",
     "matplotlib>=3.7.0",


### PR DESCRIPTION
## Summary
`astropy` was capped at `>=5.0,<=7.2.0`, so a fresh `pip install autoarray` downgrades astropy to 7.2.0 even though the stack runs and passes under 8.0.1 (PyPI latest). Drop the cap and keep the floor — `astropy>=5.0` — matching the floors-not-pins convention this dependency block already documents (#433) and the uncapped astropy floors PyAutoFit / PyAutoNerves already declare.

Part of PyAutoLabs/PyAutoArray#434; a sibling PyAutoGalaxy PR carries the same floor change.

## API Changes
None — internal changes only.

## Test Plan
- [x] `pytest test_autoarray/` — 929 passed under astropy 8.0.1
- [x] Clean-venv `pip install --dry-run`: resolves astropy 8.0.1 (control on capped main: 7.2.0)
- [x] FITS-loaded imaging fit smoke under astropy 8.0.1

<details>
<summary>Full API Changes (for automation & release notes)</summary>

None — dependency-metadata change only (`pyproject.toml` astropy specifier `>=5.0,<=7.2.0` → `>=5.0`).

</details>

Generated by the PyAutoLabs agent workflow.