### PR TITLE
fix: reject invalid constructor inputs (#333 — B5-B8, B13)

### DIFF
--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -119,6 +119,25 @@ class AbstractDataset:
                     """
                 ) from e
 
+        # Guarding on the base class covers `Imaging`, `Interferometer` and every other
+        # dataset subclass. Array shapes are static under JAX, so no tracer gate is
+        # needed here (unlike the scalar guards in `autoarray.validate`).
+        data_shape = getattr(data, "shape_native", None)
+        noise_map_shape = getattr(noise_map, "shape_native", None)
+
+        if (
+            data_shape is not None
+            and noise_map_shape is not None
+            and tuple(data_shape) != tuple(noise_map_shape)
+        ):
+            raise exc.DatasetException(
+                f"noise_map must have the same shape as data; got data with "
+                f"shape_native {tuple(data_shape)!r} and noise_map with shape_native "
+                f"{tuple(noise_map_shape)!r}. Every fit quantity pairs a data value "
+                f"with its noise value pixel-by-pixel, so a mismatch has no "
+                f"well-defined meaning"
+            )
+
         self.noise_map = noise_map
 
         self.over_sample_size_lp = (

--- a/autoarray/geometry/geometry_util.py
+++ b/autoarray/geometry/geometry_util.py
@@ -2,6 +2,7 @@ import numpy as np
 from typing import Tuple, Union
 
 from autoarray import type as ty
+from autoarray import validate
 
 
 def convert_shape_native_1d(shape_native: Union[int, Tuple[int]]) -> Tuple[int]:
@@ -46,7 +47,14 @@ def convert_pixel_scales_1d(pixel_scales: ty.PixelScales) -> Tuple[float]:
     -------
     Tuple[float]
         The pixel scale as a 1-element tuple `(float,)`.
+
+    Raises
+    ------
+    ValueError
+        If any entry is a concrete scalar which is not finite and above zero.
     """
+
+    validate.validate_pixel_scales(pixel_scales=pixel_scales)
 
     if type(pixel_scales) is float:
         pixel_scales = (pixel_scales,)
@@ -205,7 +213,20 @@ def convert_pixel_scales_2d(pixel_scales: ty.PixelScales) -> Tuple[float, float]
     -------
     Tuple[float, float]
         The pixel scale as a 2-element tuple `(float, float)`.
+
+    Raises
+    ------
+    ValueError
+        If any entry is a concrete scalar which is not finite and above zero.
+
+    Notes
+    -----
+    This is the single chokepoint every ``Mask2D`` factory and ``Grid2D.uniform``
+    funnel their ``pixel_scales`` through, so validating here covers them all rather
+    than repeating a guard at each construction site.
     """
+
+    validate.validate_pixel_scales(pixel_scales=pixel_scales)
 
     if type(pixel_scales) is float:
         pixel_scales = (pixel_scales, pixel_scales)

--- a/autoarray/inversion/regularization/abstract.py
+++ b/autoarray/inversion/regularization/abstract.py
@@ -2,8 +2,46 @@ from __future__ import annotations
 import numpy as np
 from typing import Optional, TYPE_CHECKING
 
+from autoarray import validate
+
 if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
+
+
+def validate_coefficient(coefficient, name: str = "coefficient"):
+    """
+    Raise if a regularization coefficient is a concrete scalar which is negative or
+    non-finite.
+
+    Every regularization scheme calls this from its constructor, so the message for
+    this class of mistake is written once here rather than per scheme.
+
+    Zero is permitted: it is a degenerate but meaningful request for no regularization.
+    Negative is not, and is **not** inert despite appearances — see the note below.
+
+    Coefficients are free model parameters, so under a JAX-traced fit this receives a
+    tracer rather than a number. `autoarray.validate` gates on concreteness before
+    comparing, so the guard costs nothing inside a trace.
+
+    Parameters
+    ----------
+    coefficient
+        The regularization coefficient to validate.
+    name
+        The parameter's name, used in the error message (schemes with more than one
+        coefficient pass their own, e.g. ``inner_coefficient``).
+    """
+    validate.validate_non_negative_finite(
+        value=coefficient,
+        name=name,
+        extra=(
+            "A regularization coefficient sets the strength of the smoothing applied "
+            "to the reconstruction, which cannot be negative. A negative value is not "
+            "inert: `regularization_matrix_from` squares it, which hides the sign, but "
+            "`regularization_weights_from` returns it unsquared and so leaks negative "
+            "regularization weights into every consumer of that method"
+        ),
+    )
 
 
 class AbstractRegularization:

--- a/autoarray/inversion/regularization/adapt.py
+++ b/autoarray/inversion/regularization/adapt.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def adapt_regularization_weights_from(
@@ -193,7 +194,9 @@ class Adapt(AbstractRegularization):
 
         super().__init__()
 
+        validate_coefficient(coefficient=inner_coefficient, name="inner_coefficient")
         self.inner_coefficient = inner_coefficient
+        validate_coefficient(coefficient=outer_coefficient, name="outer_coefficient")
         self.outer_coefficient = outer_coefficient
         self.signal_scale = signal_scale
 

--- a/autoarray/inversion/regularization/adapt_split_zeroth.py
+++ b/autoarray/inversion/regularization/adapt_split_zeroth.py
@@ -8,10 +8,12 @@ if TYPE_CHECKING:
 from autoarray.inversion.regularization.adapt import Adapt
 from autoarray.inversion.regularization.brightness_zeroth import BrightnessZeroth
 from autoarray.inversion.regularization import regularization_util
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 class AdaptSplitZeroth(Adapt):
     is_split_regularization = True
+
     def __init__(
         self,
         zeroth_coefficient: float = 1.0,
@@ -77,6 +79,7 @@ class AdaptSplitZeroth(Adapt):
             low signal regions.
         """
 
+        validate_coefficient(coefficient=zeroth_coefficient, name="zeroth_coefficient")
         self.zeroth_coefficient = zeroth_coefficient
         self.zeroth_signal_scale = zeroth_signal_scale
 

--- a/autoarray/inversion/regularization/brightness_zeroth.py
+++ b/autoarray/inversion/regularization/brightness_zeroth.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def brightness_zeroth_regularization_weights_from(
@@ -104,6 +105,7 @@ class BrightnessZeroth(AbstractRegularization):
 
         super().__init__()
 
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
         self.signal_scale = signal_scale
 

--- a/autoarray/inversion/regularization/constant.py
+++ b/autoarray/inversion/regularization/constant.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def constant_regularization_matrix_from(
@@ -101,6 +102,7 @@ class Constant(AbstractRegularization):
             The regularization coefficient which controls the degree of smooth of the inversion reconstruction.
         """
 
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
 
         super().__init__()

--- a/autoarray/inversion/regularization/constant_zeroth.py
+++ b/autoarray/inversion/regularization/constant_zeroth.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def constant_zeroth_regularization_matrix_from(
@@ -76,7 +77,11 @@ class ConstantZeroth(AbstractRegularization):
     def __init__(self, coefficient_neighbor=1.0, coefficient_zeroth=1.0):
         super().__init__()
 
+        validate_coefficient(
+            coefficient=coefficient_neighbor, name="coefficient_neighbor"
+        )
         self.coefficient_neighbor = coefficient_neighbor
+        validate_coefficient(coefficient=coefficient_zeroth, name="coefficient_zeroth")
         self.coefficient_zeroth = coefficient_zeroth
 
     def regularization_weights_from(self, linear_obj: LinearObj, xp=np) -> np.ndarray:

--- a/autoarray/inversion/regularization/curvature_mask.py
+++ b/autoarray/inversion/regularization/curvature_mask.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
 from autoarray.operators import derivative_util
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def curvature_reg_matrix_via_mask_from(mask, pixel_scale: float = 1.0) -> np.ndarray:
@@ -71,6 +72,7 @@ class CurvatureMask(AbstractRegularization):
             The regularization coefficient which multiplies the matrix,
             setting the strength of the smoothing.
         """
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
 
         super().__init__()

--- a/autoarray/inversion/regularization/exponential_kernel.py
+++ b/autoarray/inversion/regularization/exponential_kernel.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def exp_cov_matrix_from(
@@ -110,6 +111,7 @@ class ExponentialKernel(AbstractRegularization):
             convention assumes ``C_ii ~ 1``, which holds for this unweighted kernel but not
             for the adaptive one; see :func:`apply_jitter` for why and when to switch.
         """
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
         self.scale = scale
         self.jitter = jitter

--- a/autoarray/inversion/regularization/fourth_order_mask.py
+++ b/autoarray/inversion/regularization/fourth_order_mask.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 from autoarray.operators import derivative_util
 
 
@@ -74,6 +75,7 @@ class FourthOrderMask(AbstractRegularization):
             The regularization coefficient which multiplies the matrix,
             setting the strength of the smoothing.
         """
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
 
         super().__init__()

--- a/autoarray/inversion/regularization/gaussian_kernel.py
+++ b/autoarray/inversion/regularization/gaussian_kernel.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def gauss_cov_matrix_from(
@@ -100,6 +101,7 @@ class GaussianKernel(AbstractRegularization):
             convention assumes ``C_ii ~ 1``, which holds for this unweighted kernel but not
             for the adaptive one; see :func:`apply_jitter` for why and when to switch.
         """
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
         self.scale = scale
         self.jitter = jitter

--- a/autoarray/inversion/regularization/matern_adapt_kernel.py
+++ b/autoarray/inversion/regularization/matern_adapt_kernel.py
@@ -14,6 +14,7 @@ from autoarray.inversion.regularization.matern_kernel import (
     quadratic_form_via_cholesky,
 )
 from autoarray.inversion.regularization.adapt import adapt_regularization_weights_from
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 class MaternAdaptKernel(MaternKernel):
@@ -86,7 +87,9 @@ class MaternAdaptKernel(MaternKernel):
             jitter=jitter,
             jitter_relative=jitter_relative,
         )
+        validate_coefficient(coefficient=inner_coefficient, name="inner_coefficient")
         self.inner_coefficient = inner_coefficient
+        validate_coefficient(coefficient=outer_coefficient, name="outer_coefficient")
         self.outer_coefficient = outer_coefficient
         self.signal_scale = signal_scale
 

--- a/autoarray/inversion/regularization/matern_kernel.py
+++ b/autoarray/inversion/regularization/matern_kernel.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def kv_xp(v, z, xp=np):
@@ -318,6 +319,7 @@ class MaternKernel(AbstractRegularization):
             for the adaptive one; see :func:`apply_jitter` for why and when to switch.
         """
 
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
         self.scale = scale
         self.nu = nu

--- a/autoarray/inversion/regularization/zeroth.py
+++ b/autoarray/inversion/regularization/zeroth.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from autoarray.inversion.linear_obj.linear_obj import LinearObj
 
 from autoarray.inversion.regularization.abstract import AbstractRegularization
+from autoarray.inversion.regularization.abstract import validate_coefficient
 
 
 def zeroth_regularization_matrix_from(
@@ -70,6 +71,7 @@ class Zeroth(AbstractRegularization):
             The regularization coefficient which controls the degree of smooth of the inversion reconstruction.
         """
 
+        validate_coefficient(coefficient=coefficient)
         self.coefficient = coefficient
 
         super().__init__()

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -20,6 +20,7 @@ from autoarray.mask.abstract_mask import Mask
 
 from autoarray import exc
 from autoarray import type as ty
+from autoarray import validate
 from autoarray.geometry.geometry_2d import Geometry2D
 from autoarray.mask.derive.mask_2d import DeriveMask2D
 from autoarray.mask.derive.grid_2d import DeriveGrid2D
@@ -218,6 +219,13 @@ class Mask2D(Mask):
 
         if len(mask.shape) != 2:
             raise exc.MaskException("The input mask is not a two dimensional array")
+
+        # Every `Mask2D` factory returns through this constructor, and `Grid2D.uniform`
+        # reaches it via `Grid2D.no_mask` -> `Mask2D.all_false`, so a degenerate shape
+        # is caught once here rather than at each construction site.
+        validate.validate_shape_native(
+            shape_native=mask.shape, name="shape_native", exc_type=exc.MaskException
+        )
 
         super().__init__(
             mask=mask,
@@ -426,6 +434,12 @@ class Mask2D(Mask):
             and visa versa.
         """
 
+        validate.validate_radii_ordered(
+            inner_radius=inner_radius,
+            outer_radius=outer_radius,
+            exc_type=exc.MaskException,
+        )
+
         pixel_scales = geometry_util.convert_pixel_scales_2d(pixel_scales=pixel_scales)
 
         mask = mask_2d_util.mask_2d_circular_annular_from(
@@ -549,6 +563,14 @@ class Mask2D(Mask):
             If `True`, the `bool`'s of the input `mask` are inverted, for example `False`'s become `True`
             and visa versa.
         """
+        validate.validate_radii_ordered(
+            inner_radius=inner_major_axis_radius,
+            outer_radius=outer_major_axis_radius,
+            inner_name="inner_major_axis_radius",
+            outer_name="outer_major_axis_radius",
+            exc_type=exc.MaskException,
+        )
+
         pixel_scales = geometry_util.convert_pixel_scales_2d(pixel_scales=pixel_scales)
 
         mask = mask_2d_util.mask_2d_elliptical_annular_from(

--- a/autoarray/validate.py
+++ b/autoarray/validate.py
@@ -1,0 +1,275 @@
+"""
+Shared constructor-input validation helpers.
+
+**This module is the agreed home for the PyAuto validation guards.** PyAutoArray is
+the floor that PyAutoGalaxy and PyAutoLens both build on, so the guards live here
+and are imported downstream (``from autoarray import validate``) rather than being
+re-invented per repo. That keeps one message shape for one class of mistake across
+all three libraries — the failure mode this module exists to prevent is three repos
+telling a user three different things about the same bad input.
+
+__Message shape__
+
+Every message names the parameter, states the rule, and shows what was received:
+
+::
+
+    pixel_scales must be a finite positive number; got -0.1
+
+Callers may append a sentence of context (``extra``) when the rule alone is not
+enough to act on, e.g. pointing out that swapped arguments are the usual cause.
+
+__Tracer safety__
+
+These constructors sit on JAX-traced paths — ``coefficient`` in particular is a
+free model parameter, so under a traced fit a constructor is handed a JAX tracer
+rather than a number. A plain ``if value < 0`` on a tracer raises
+``TracerBoolConversionError``, so **every value guard here is gated on
+:func:`is_concrete_scalar` first** and silently passes anything it does not
+recognise. The guards therefore catch the mistakes a human makes when writing a
+script by hand (which is where all of these were reported) and cost nothing inside
+a trace.
+
+The same reasoning already appears at ``autoarray/dataset/imaging/simulator.py``,
+where a NaN check is guarded by ``if xp is np``. A constructor has no ``xp``
+argument to test, so the value's own type is the gate instead.
+
+Shape checks need no such gate: array shapes are static under JAX, so a shape is
+always concrete.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, Tuple, Type, Union
+
+import numpy as np
+
+
+def is_concrete_scalar(value: Any) -> bool:
+    """
+    Returns ``True`` if ``value`` is a concrete Python or NumPy real scalar, and is
+    therefore safe to compare against with a plain Python ``if``.
+
+    This is the gate that makes every guard in this module tracer-safe. A JAX tracer,
+    a ``numpy`` array, ``None``, a string or any other object returns ``False`` and is
+    passed through unvalidated — a guard's job is to catch obvious hand-written
+    mistakes, not to police types inside a trace.
+
+    ``bool`` is excluded deliberately: it is a subclass of ``int`` in Python, and
+    ``True`` reaching a numeric parameter is a different mistake than the ones these
+    guards describe.
+
+    Parameters
+    ----------
+    value
+        The value to test.
+    """
+    if isinstance(value, bool):
+        return False
+
+    return isinstance(value, (int, float, np.integer, np.floating))
+
+
+def _raise(
+    name: str,
+    rule: str,
+    value: Any,
+    exc_type: Type[Exception],
+    extra: str = "",
+):
+    message = f"{name} must be {rule}; got {value!r}"
+
+    if extra:
+        message = f"{message}. {extra}"
+
+    raise exc_type(message)
+
+
+def validate_positive_finite(
+    value: Any,
+    name: str,
+    exc_type: Type[Exception] = ValueError,
+    extra: str = "",
+):
+    """
+    Raise if ``value`` is a concrete scalar which is not finite and strictly positive.
+
+    Used for quantities where zero is as meaningless as a negative — a ``pixel_scales``
+    of ``0.0`` makes every pixel-to-scaled conversion a division by zero, and a
+    negative one silently flips the geometry.
+
+    Non-concrete values (e.g. a JAX tracer) are passed through — see the module
+    docstring.
+
+    Parameters
+    ----------
+    value
+        The value to validate.
+    name
+        The parameter name, used in the error message so the caller knows what to fix.
+    exc_type
+        The exception type to raise, so a module can raise its own (e.g.
+        ``exc.MaskException``) instead of the ``ValueError`` default.
+    extra
+        An optional sentence of extra guidance appended to the message.
+    """
+    if not is_concrete_scalar(value):
+        return
+
+    if not np.isfinite(value) or value <= 0:
+        _raise(name, "a finite positive number", value, exc_type, extra)
+
+
+def validate_non_negative_finite(
+    value: Any,
+    name: str,
+    exc_type: Type[Exception] = ValueError,
+    extra: str = "",
+):
+    """
+    Raise if ``value`` is a concrete scalar which is not finite and non-negative.
+
+    Used where zero is a meaningful (if degenerate) request but a negative value is
+    not — a regularization ``coefficient`` of ``0.0`` legitimately means "do not
+    regularize", whereas a negative one is unphysical.
+
+    Non-concrete values (e.g. a JAX tracer) are passed through — see the module
+    docstring.
+
+    Parameters
+    ----------
+    value
+        The value to validate.
+    name
+        The parameter name, used in the error message so the caller knows what to fix.
+    exc_type
+        The exception type to raise.
+    extra
+        An optional sentence of extra guidance appended to the message.
+    """
+    if not is_concrete_scalar(value):
+        return
+
+    if not np.isfinite(value) or value < 0:
+        _raise(name, "a finite non-negative number", value, exc_type, extra)
+
+
+def validate_pixel_scales(
+    pixel_scales: Union[float, Tuple[float, ...]],
+    name: str = "pixel_scales",
+    exc_type: Type[Exception] = ValueError,
+):
+    """
+    Raise if any entry of ``pixel_scales`` is a concrete scalar which is not finite and
+    strictly positive.
+
+    Accepts either the single-``float`` or the per-axis tuple form, because it is
+    called at the conversion chokepoint which sees both.
+
+    Parameters
+    ----------
+    pixel_scales
+        The pixel scale to validate, as a scalar or a tuple of per-axis scalars.
+    name
+        The parameter name used in the error message.
+    exc_type
+        The exception type to raise.
+    """
+    extra = (
+        "A pixel scale is the scaled-units size of one pixel, so it must be above "
+        "zero: a value of 0.0 makes every pixel-to-scaled conversion a division by "
+        "zero, and a negative value silently flips the coordinate system"
+    )
+
+    if isinstance(pixel_scales, (tuple, list)):
+        for index, pixel_scale in enumerate(pixel_scales):
+            validate_positive_finite(
+                value=pixel_scale,
+                name=f"{name}[{index}]",
+                exc_type=exc_type,
+                extra=extra,
+            )
+        return
+
+    validate_positive_finite(
+        value=pixel_scales, name=name, exc_type=exc_type, extra=extra
+    )
+
+
+def validate_shape_native(
+    shape_native: Sequence[int],
+    name: str = "shape_native",
+    exc_type: Type[Exception] = ValueError,
+):
+    """
+    Raise if any entry of ``shape_native`` is not a positive integer.
+
+    A zero-length axis produces a structure with no pixels at all, which every
+    downstream calculation then silently returns nothing for, rather than failing
+    where the mistake was made.
+
+    Parameters
+    ----------
+    shape_native
+        The (y,x) shape in pixels to validate.
+    name
+        The parameter name used in the error message.
+    exc_type
+        The exception type to raise.
+    """
+    for index, length in enumerate(shape_native):
+        if not is_concrete_scalar(length):
+            continue
+
+        if length <= 0:
+            _raise(
+                f"{name}[{index}]",
+                "a positive number of pixels",
+                length,
+                exc_type,
+                f"The full {name} input was {tuple(shape_native)!r}, which describes a "
+                f"structure containing no pixels",
+            )
+
+
+def validate_radii_ordered(
+    inner_radius: Any,
+    outer_radius: Any,
+    inner_name: str = "inner_radius",
+    outer_name: str = "outer_radius",
+    exc_type: Type[Exception] = ValueError,
+):
+    """
+    Raise if a concrete ``inner_radius`` is not strictly less than a concrete
+    ``outer_radius``, or if either is negative or non-finite.
+
+    An annulus whose inner radius is the larger of the two contains no pixels at all.
+    That is almost always the two arguments being passed the wrong way round, so the
+    message says so.
+
+    Parameters
+    ----------
+    inner_radius
+        The inner radius of the annulus.
+    outer_radius
+        The outer radius of the annulus.
+    inner_name
+        The inner parameter's name, used in the error message.
+    outer_name
+        The outer parameter's name, used in the error message.
+    exc_type
+        The exception type to raise.
+    """
+    validate_non_negative_finite(value=inner_radius, name=inner_name, exc_type=exc_type)
+    validate_positive_finite(value=outer_radius, name=outer_name, exc_type=exc_type)
+
+    if not is_concrete_scalar(inner_radius) or not is_concrete_scalar(outer_radius):
+        return
+
+    if inner_radius >= outer_radius:
+        raise exc_type(
+            f"{inner_name} must be less than {outer_name}; got {inner_name}="
+            f"{inner_radius!r} and {outer_name}={outer_radius!r}. An annulus whose "
+            f"inner radius is not smaller than its outer radius contains no pixels — "
+            f"the usual cause is the two arguments being passed the wrong way round"
+        )

--- a/test_autoarray/test_validate.py
+++ b/test_autoarray/test_validate.py
@@ -1,0 +1,321 @@
+"""
+Regression tests for PyAutoArray#333 — constructor input validation.
+
+Each test in the "findings" section is built from @rhayes777's own snippet in the
+issue body, and asserts the *failure*: that the input is rejected at construction
+with a message naming the offending parameter, rather than accepted and surfaced as
+a confusing traceback several calls later (or, worse, silently accepted).
+
+Each finding is paired with a control asserting the valid input still works, so a
+guard cannot pass by rejecting everything.
+
+Tests are numpy-only, per phase 1 — the tracer-safety property is asserted against
+the concreteness gate itself (`is_concrete_scalar`), which is what the guards
+branch on, rather than by importing JAX into the library unit tests.
+"""
+
+import numpy as np
+import pytest
+
+import autoarray as aa
+from autoarray import exc
+from autoarray import validate
+
+
+class _NotAConcreteScalar:
+    """
+    Stand-in for a JAX tracer: an object that is not a concrete Python/NumPy scalar
+    and which raises if anything tries to resolve it to a bool, exactly as a tracer
+    does inside `jax.jit`.
+    """
+
+    def __bool__(self):
+        raise AssertionError(
+            "a guard compared a non-concrete value — this is the TracerBoolConversionError path"
+        )
+
+    def __lt__(self, other):
+        return self
+
+    def __le__(self, other):
+        return self
+
+    def __ge__(self, other):
+        return self
+
+
+# ======================================================================================
+# The concreteness gate
+# ======================================================================================
+
+
+def test__is_concrete_scalar__true_for_python_and_numpy_real_scalars():
+    assert validate.is_concrete_scalar(1)
+    assert validate.is_concrete_scalar(1.5)
+    assert validate.is_concrete_scalar(-3)
+    assert validate.is_concrete_scalar(np.float64(1.5))
+    assert validate.is_concrete_scalar(np.int32(2))
+
+
+def test__is_concrete_scalar__false_for_bool_none_arrays_and_tracer_likes():
+    assert not validate.is_concrete_scalar(True)
+    assert not validate.is_concrete_scalar(None)
+    assert not validate.is_concrete_scalar("1.0")
+    assert not validate.is_concrete_scalar(np.array([1.0, 2.0]))
+    assert not validate.is_concrete_scalar(_NotAConcreteScalar())
+
+
+def test__guards_pass_through_non_concrete_values__never_compare_them():
+    """
+    The binding JAX constraint: a guard must not evaluate a Python truth-test on a
+    value that may be a tracer. `_NotAConcreteScalar.__bool__` raises, so these calls
+    returning cleanly is the assertion.
+    """
+    tracer_like = _NotAConcreteScalar()
+
+    validate.validate_positive_finite(value=tracer_like, name="pixel_scales")
+    validate.validate_non_negative_finite(value=tracer_like, name="coefficient")
+    validate.validate_pixel_scales(pixel_scales=tracer_like)
+    validate.validate_pixel_scales(pixel_scales=(tracer_like, tracer_like))
+    validate.validate_radii_ordered(inner_radius=tracer_like, outer_radius=tracer_like)
+    validate.validate_shape_native(shape_native=(tracer_like, tracer_like))
+
+
+def test__regularization_constructors__accept_a_tracer_like_coefficient():
+    """A free model parameter arrives as a tracer under a traced fit; it must build."""
+    tracer_like = _NotAConcreteScalar()
+
+    assert aa.reg.Constant(coefficient=tracer_like).coefficient is tracer_like
+    assert (
+        aa.reg.Adapt(
+            inner_coefficient=tracer_like, outer_coefficient=tracer_like
+        ).inner_coefficient
+        is tracer_like
+    )
+
+
+# ======================================================================================
+# B6 — pixel_scales must be finite and positive
+# ======================================================================================
+
+
+@pytest.mark.parametrize("pixel_scales", [0.0, -0.1, float("nan"), float("inf")])
+def test__b6__array_2d_rejects_non_positive_or_non_finite_pixel_scales(pixel_scales):
+    with pytest.raises(ValueError, match="pixel_scales"):
+        aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=pixel_scales)
+
+
+@pytest.mark.parametrize("pixel_scales", [0.0, -0.1, float("nan")])
+def test__b6__mask_2d_rejects_non_positive_or_non_finite_pixel_scales(pixel_scales):
+    with pytest.raises(ValueError, match="pixel_scales"):
+        aa.Mask2D.circular(shape_native=(5, 5), radius=1.0, pixel_scales=pixel_scales)
+
+
+def test__b6__per_axis_pixel_scales_are_validated_and_the_message_names_the_axis():
+    with pytest.raises(ValueError, match=r"pixel_scales\[1\]"):
+        aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=(0.1, -0.1))
+
+
+def test__b6__control__valid_pixel_scales_still_build():
+    array = aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=0.1)
+    assert array.pixel_scales == (0.1, 0.1)
+
+    array = aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=(0.1, 0.2))
+    assert array.pixel_scales == (0.1, 0.2)
+
+
+# ======================================================================================
+# B7 — annulus radii must be ordered
+# ======================================================================================
+
+
+def test__b7__circular_annular_rejects_inner_radius_above_outer_radius():
+    with pytest.raises(exc.MaskException, match="inner_radius"):
+        aa.Mask2D.circular_annular(
+            shape_native=(10, 10),
+            inner_radius=0.8,
+            outer_radius=0.3,
+            pixel_scales=0.1,
+        )
+
+
+def test__b7__circular_annular_rejects_equal_radii():
+    with pytest.raises(exc.MaskException, match="inner_radius"):
+        aa.Mask2D.circular_annular(
+            shape_native=(10, 10),
+            inner_radius=0.5,
+            outer_radius=0.5,
+            pixel_scales=0.1,
+        )
+
+
+def test__b7__elliptical_annular_rejects_inner_major_axis_above_outer():
+    with pytest.raises(exc.MaskException, match="inner_major_axis_radius"):
+        aa.Mask2D.elliptical_annular(
+            shape_native=(10, 10),
+            inner_major_axis_radius=0.8,
+            inner_axis_ratio=1.0,
+            inner_phi=0.0,
+            outer_major_axis_radius=0.3,
+            outer_axis_ratio=1.0,
+            outer_phi=0.0,
+            pixel_scales=0.1,
+        )
+
+
+def test__b7__control__well_ordered_annulus_still_builds_and_is_not_empty():
+    mask = aa.Mask2D.circular_annular(
+        shape_native=(10, 10), inner_radius=0.3, outer_radius=0.8, pixel_scales=0.1
+    )
+    assert mask.pixels_in_mask == 68
+
+
+# ======================================================================================
+# B8 — shape_native must have no zero-length axis
+# ======================================================================================
+
+
+@pytest.mark.parametrize("shape_native", [(0, 0), (0, 5), (5, 0)])
+def test__b8__grid_2d_uniform_rejects_a_zero_length_axis(shape_native):
+    with pytest.raises(exc.MaskException, match="shape_native"):
+        aa.Grid2D.uniform(shape_native=shape_native, pixel_scales=0.1)
+
+
+def test__b8__mask_2d_all_false_rejects_a_zero_length_axis():
+    with pytest.raises(exc.MaskException, match="shape_native"):
+        aa.Mask2D.all_false(shape_native=(0, 5), pixel_scales=0.1)
+
+
+def test__b8__control__a_non_degenerate_grid_still_builds():
+    grid = aa.Grid2D.uniform(shape_native=(5, 5), pixel_scales=0.1)
+    assert grid.shape_slim == 25
+
+
+# ======================================================================================
+# B5 — data and noise_map shapes must agree
+# ======================================================================================
+
+
+def test__b5__imaging_rejects_a_noise_map_whose_shape_differs_from_the_data():
+    data = aa.Array2D.no_mask(values=np.ones((10, 10)), pixel_scales=0.1)
+    noise_map = aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=0.1)
+
+    with pytest.raises(exc.DatasetException, match="noise_map"):
+        aa.Imaging(data=data, noise_map=noise_map)
+
+
+def test__b5__the_message_reports_both_shapes():
+    data = aa.Array2D.no_mask(values=np.ones((10, 10)), pixel_scales=0.1)
+    noise_map = aa.Array2D.no_mask(values=np.ones((5, 5)), pixel_scales=0.1)
+
+    with pytest.raises(exc.DatasetException) as error:
+        aa.Imaging(data=data, noise_map=noise_map)
+
+    assert "(10, 10)" in str(error.value)
+    assert "(5, 5)" in str(error.value)
+
+
+def test__b5__control__matched_shapes_still_build():
+    data = aa.Array2D.no_mask(values=np.ones((10, 10)), pixel_scales=0.1)
+    noise_map = aa.Array2D.no_mask(values=np.ones((10, 10)), pixel_scales=0.1)
+
+    dataset = aa.Imaging(data=data, noise_map=noise_map)
+
+    assert dataset.shape_native == (10, 10)
+
+
+# ======================================================================================
+# B13 — regularization coefficients must be non-negative
+# ======================================================================================
+
+
+def test__b13__constant_rejects_a_negative_coefficient():
+    with pytest.raises(ValueError, match="coefficient"):
+        aa.reg.Constant(coefficient=-1.0)
+
+
+@pytest.mark.parametrize(
+    "regularization_cls",
+    [
+        aa.reg.Constant,
+        aa.reg.ConstantSplit,
+        aa.reg.Zeroth,
+        aa.reg.BrightnessZeroth,
+        aa.reg.CurvatureMask,
+        aa.reg.FourthOrderMask,
+        aa.reg.ExponentialKernel,
+        aa.reg.GaussianKernel,
+        aa.reg.MaternKernel,
+    ],
+)
+def test__b13__every_single_coefficient_scheme_rejects_a_negative_coefficient(
+    regularization_cls,
+):
+    """The reporter named `Constant`; the same hole was open in every sibling scheme."""
+    with pytest.raises(ValueError, match="coefficient"):
+        regularization_cls(coefficient=-1.0)
+
+
+@pytest.mark.parametrize(
+    "regularization_cls", [aa.reg.Adapt, aa.reg.AdaptSplit, aa.reg.MaternAdaptKernel]
+)
+def test__b13__inner_and_outer_coefficient_schemes_reject_negatives(regularization_cls):
+    with pytest.raises(ValueError, match="inner_coefficient"):
+        regularization_cls(inner_coefficient=-1.0, outer_coefficient=1.0)
+
+    with pytest.raises(ValueError, match="outer_coefficient"):
+        regularization_cls(inner_coefficient=1.0, outer_coefficient=-1.0)
+
+
+def test__b13__constant_zeroth_rejects_negatives_on_both_coefficients():
+    with pytest.raises(ValueError, match="coefficient_neighbor"):
+        aa.reg.ConstantZeroth(coefficient_neighbor=-1.0, coefficient_zeroth=1.0)
+
+    with pytest.raises(ValueError, match="coefficient_zeroth"):
+        aa.reg.ConstantZeroth(coefficient_neighbor=1.0, coefficient_zeroth=-1.0)
+
+
+def test__b13__adapt_split_zeroth_rejects_a_negative_zeroth_coefficient():
+    with pytest.raises(ValueError, match="zeroth_coefficient"):
+        aa.reg.AdaptSplitZeroth(
+            zeroth_coefficient=-1.0, inner_coefficient=1.0, outer_coefficient=1.0
+        )
+
+
+def test__b13__nan_and_inf_coefficients_are_rejected():
+    with pytest.raises(ValueError, match="coefficient"):
+        aa.reg.Constant(coefficient=float("nan"))
+
+    with pytest.raises(ValueError, match="coefficient"):
+        aa.reg.Constant(coefficient=float("inf"))
+
+
+def test__b13__control__zero_is_permitted_as_a_request_for_no_regularization():
+    """Zero is degenerate but meaningful, unlike a negative — it must not be rejected."""
+    assert aa.reg.Constant(coefficient=0.0).coefficient == 0.0
+
+
+def test__b13__control__a_positive_coefficient_still_builds():
+    assert aa.reg.Constant(coefficient=1.0).coefficient == 1.0
+
+
+class _MockLinearObj:
+    params = 4
+
+
+def test__b13__the_sharpened_finding__negative_weights_can_no_longer_leak():
+    """
+    `regularization_matrix_from` squares the coefficient, which hides the sign and led
+    the reporter to read a negative value as inert. `regularization_weights_from`
+    returns it *unsquared*, so a negative coefficient leaked negative regularization
+    weights into every consumer of that method. Rejecting at construction closes it.
+    """
+    weights = aa.reg.Constant(coefficient=2.0).regularization_weights_from(
+        linear_obj=_MockLinearObj()
+    )
+    assert np.all(np.asarray(weights) >= 0)
+
+    with pytest.raises(ValueError, match="coefficient"):
+        aa.reg.Constant(coefficient=-1.0).regularization_weights_from(
+            linear_obj=_MockLinearObj()
+        )


### PR DESCRIPTION
Closes #333. Implements #439. Phase 2 (PyAutoArray half) of the @rhayes777 API audit epic #415, which stays open for phases 3-4.

## What this fixes

Five findings from @rhayes777's 2026-05-23 audit, all still reproducing on `main` when this branch was cut. Each was *"accepted silently, then a confusing traceback (or nothing at all) several calls later"*; each now raises at construction with a message naming the offending parameter.

| ID | Input | Before | After |
|---|---|---|---|
| B6 | `pixel_scales` of `0.0` / `-0.1` / `nan` | accepted; `ZeroDivisionError` on the first `derive_grid`, or a silently flipped coordinate system | `ValueError` naming `pixel_scales` |
| B7 | `circular_annular(inner_radius=0.8, outer_radius=0.3)` | accepted, `pixels_in_mask == 0` | `MaskException` naming both radii |
| B8 | `Grid2D.uniform(shape_native=(0, 5))` | accepted, `shape_slim == 0` | `MaskException` naming the axis |
| B5 | `Imaging(data 10x10, noise_map 5x5)` | built; `shape_native` reported `(10, 10)`, mismatch swallowed | `DatasetException` reporting both shapes |
| B13 | `reg.Constant(coefficient=-1.0)` | accepted, stored as `-1.0` | `ValueError` naming `coefficient` |

Guards sit at **chokepoints** rather than at the five reported call sites, so coverage is wider than the report:

- **B6** — `geometry_util.convert_pixel_scales_{1d,2d}`, which every `Mask2D` factory and `Grid2D.uniform` funnel through.
- **B8** — `Mask2D.__init__`, which every factory returns through (`Grid2D.uniform` reaches it via `no_mask` → `all_false`).
- **B7** — `circular_annular` **and** `elliptical_annular`, which had the identical hole.
- **B5** — `AbstractDataset.__init__`, so `Interferometer` and every other subclass are covered, not just the reported `Imaging`.
- **B13** — **all 14 regularization schemes**, not only the reported `Constant`. Thirteen siblings had the same hole.

## B13 is a real leak, not a cosmetic one

The reporter read a negative coefficient as inert because `log_evidence` is identical for `+1.0` and `-1.0`. That is `regularization_matrix_from` squaring it (`constant.py:43`) and hiding the sign. But `regularization_weights_from` returns the coefficient **unsquared**, so a negative value fed negative regularization weights to every consumer of that method. Confirmed empirically before fixing:

```
Constant(-1.0).regularization_weights_from  ->  [-1. -1. -1. -1.]
```

Rejecting at construction is what closes it.

## The shared `_validate_*` home — the decision this task owned

`autoarray/validate.py`, public. PyAutoArray is the floor PyAutoGalaxy and PyAutoLens both build on, so the blocked sibling prompts (PyAutoGalaxy#440, PyAutoLens#532) import it — `from autoarray import validate` — rather than restating the same rules with different wording in three repos.

Message shape, applied everywhere: **name the parameter, state the rule, show the received value**, plus an optional sentence of guidance.

```
pixel_scales must be a finite positive number; got -0.1. A pixel scale is the
scaled-units size of one pixel, so it must be above zero: ...
```

## Tracer safety (the binding constraint from phase 1)

Coefficients are free model parameters, so under a traced fit a constructor receives a JAX tracer, not a number — a plain `if value < 0` would raise `TracerBoolConversionError`. Every value guard is gated on `is_concrete_scalar` and passes non-concrete values straight through. Shape checks need no gate: shapes are static under tracing.

This was **verified against real JAX (0.11.0)**, not just asserted:

- construction of `reg.Constant` / `reg.Adapt` inside `jax.jit` with tracer coefficients — works
- `jax.grad` through a traced coefficient — flows (grad `16.0` for `sum((c·1)²)` at `c=2` over 4 params, as expected)
- a concrete `-1.0` outside a trace — still rejected

The committed tests stay numpy-only per phase 1, and assert the property against the concreteness gate itself.

## API Changes

No signatures, names or return types change. The change is in **accepted input domain**: inputs that were previously accepted and produced degenerate or misleading objects now raise at construction.

- `pixel_scales` must be finite and `> 0` (previously `0.0`, negative and `nan` were accepted).
- `shape_native` must have no zero-length axis (previously accepted, giving `shape_slim == 0`).
- Annulus constructors require `inner_radius < outer_radius` (previously accepted, giving an empty mask).
- A dataset's `noise_map` must match its `data` shape (previously accepted).
- Regularization coefficients must be finite and `>= 0` (previously any value accepted). **Zero is still permitted** — a degenerate but meaningful "no regularization" request.

No workspace script relies on any of the newly-rejected inputs; the full library suite contained no test that did either (see below).

## Test Plan

- **New:** `test_autoarray/test_validate.py` — 44 cases. One regression test per finding built from the reporter's own snippets, asserting the *failure* and that the message names the parameter; plus a **control per finding** asserting the valid input still works, so no guard can pass by rejecting everything.
- **Full suite:** `980 passed, 52 skipped`.
- **Pre-existing failures, not caused by this branch:** the 3 pynufft tests in `test_autoarray/operators/test_transformer.py` fail identically on unmodified `main` — baselined by stashing this branch's changes and re-running. Tracked separately.
- **Zero regressions.**

One note worth recording: the anticipated risk was that guards this central would surface existing tests constructing degenerate objects on purpose, each needing triage. That count was **zero** — nothing in the suite relied on a zero pixel scale, an empty shape, a swapped annulus, a mismatched noise map, or a negative coefficient.

## Out of scope

- PyAutoGalaxy#440 profile guards and PyAutoLens#532 `Tracer` guards — sibling prompts, unblocked by this PR's helper.
- PyAutoArray#332 `adapt_images` precondition legibility — phase 3, independent.
- `z_lens > z_source` — phase 4, HELD on the reporter's answer.
- **Adjacent defect found, deliberately not fixed here:** `convert_pixel_scales_2d` tests `type(pixel_scales) is float`, so an `int` pixel scale is never widened to a tuple. Worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PgqSCLTemK5bApVAwhVM4)_