### PR TITLE
docs: align curvature diagonal floor documentation

### DIFF
--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -46,15 +46,30 @@ def curvature_matrix_with_added_to_diag_from(
     It is common for the `curvature_matrix` computed to not be positive-definite, leading for the inversion
     via `np.linalg.solve` to fail and raise a `LinAlgError`.
 
-    In many circumstances, adding a small numerical value of `1.0e-8` to the diagonal of the `curvature_matrix`
+    In many circumstances, adding a small numerical value to the diagonal of the `curvature_matrix`
     makes it positive definite, such that the inversion is performed without raising an error.
 
-    This function adds this numerical value to the diagonal of the curvature matrix.
+    This function adds the caller-supplied `value` to the diagonal entries selected by
+    `no_regularization_index_list`. The normal inversion path reads this value from
+    `Settings.no_regularization_add_to_curvature_diag_value`; the packaged configuration defaults to
+    `1.0e-3`, and workspaces may override it. The addition is absolute, so its effect depends on the scale of
+    the curvature matrix.
 
     Parameters
     ----------
     curvature_matrix
         The curvature matrix which is being constructed in order to solve a linear system of equations.
+    value
+        The numerical value added to each selected diagonal entry.
+    no_regularization_index_list
+        The indices of parameters without regularization whose diagonal entries receive `value`.
+    xp
+        The array module to use (`numpy` by default; pass `jax.numpy` for JAX support).
+
+    Returns
+    -------
+    ndarray
+        The curvature matrix with `value` added to the selected diagonal entries.
     """
     if xp.__name__.startswith("jax"):
         return curvature_matrix.at[

--- a/autoarray/settings.py
+++ b/autoarray/settings.py
@@ -84,6 +84,8 @@ class Settings:
         no_regularization_add_to_curvature_diag_value
             If a linear func object does not have a corresponding regularization, this value is added to its
             diagonal entries of the curvature regularization matrix to ensure the matrix is positive-definite.
+            The packaged configuration defaults to `1.0e-3`; workspaces may override it. The addition is absolute,
+            so its effect depends on the scale of the curvature matrix.
         nnls_solver_tol
             Convergence tolerance (infinity-norm KKT residual) of the JAX positive-only (NNLS) interior-point
             solve. `None` (default) uses jaxnnls's own tolerance ``min(n * eps * 5e3, 1e-2)`` (~1.7e-9 at


### PR DESCRIPTION
## Summary
Corrects the five-order-of-magnitude documentation/configuration mismatch identified by the likelihood-tier hazard profiler.

The curvature-diagonal helper now describes the caller-supplied value, the packaged `1.0e-3` default, workspace overrides, and the absolute scale dependence. The corresponding `Settings` parameter documentation now states the same contract. Numerical behavior and configuration are unchanged.

Closes #443.

## API Changes
None — documentation-only internal clarification; no signatures, defaults, or behavior changed.

## Test Plan
- [x] PyAutoArray CI test matrix passes on Python 3.12 and 3.13 (run 31743635821).
- [x] Exact branch diff inspected: one commit, two documentation-only files, no configuration or executable statements changed.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

None.

</details>

Generated by the PyAutoLabs agent workflow.
