### PR TITLE
fix: stabilize border relocation for degenerate PCA axes

### DIFF
--- a/autoarray/inversion/mesh/border_relocator.py
+++ b/autoarray/inversion/mesh/border_relocator.py
@@ -249,6 +249,15 @@ def ellipse_params_via_border_pca_from(border_grid, xp=np, eps=1e-12):
 
     phi = xp.arctan2(v_major[1], v_major[0])
 
+    # PCA eigenvectors are undefined for an isotropic covariance. NumPy and
+    # JAX may therefore choose different, equally valid orientations whose
+    # downstream max-extent ellipses are not equivalent. Use a deterministic
+    # axis-aligned frame when the eigenvalue gap is at floating-point scale.
+    eigenvalue_scale = xp.maximum(xp.max(xp.abs(evals)), eps)
+    relative_gap = (evals[-1] - evals[0]) / eigenvalue_scale
+    isotropy_tolerance = xp.sqrt(xp.finfo(C.dtype).eps)
+    phi = xp.where(relative_gap <= isotropy_tolerance, 0.0, phi)
+
     # Rotate border points into ellipse-aligned frame
     c = xp.cos(phi)
     s = xp.sin(phi)

--- a/test_autoarray/inversion/pixelization/test_border_relocator.py
+++ b/test_autoarray/inversion/pixelization/test_border_relocator.py
@@ -4,6 +4,7 @@ import pytest
 import autoarray as aa
 
 from autoarray.inversion.mesh.border_relocator import (
+    ellipse_params_via_border_pca_from,
     sub_border_pixel_slim_indexes_from,
 )
 
@@ -376,3 +377,40 @@ def test__relocated_grid_from__positive_origin_included_in_relocate():
     relocated_grid = border_relocator.relocated_grid_from(grid=grid)
 
     assert relocated_grid.over_sampled[1] == pytest.approx([1.95, 1.0], 1e-4)
+
+def test__ellipse_params__near_isotropic_border_uses_deterministic_axis():
+    border_grid = np.array(
+        [
+            [-0.0960155108, 0.0960155108],
+            [-0.55, 0.0],
+            [-0.0960155108, -0.0960155108],
+            [0.0, 0.55],
+            [0.0, -0.55],
+            [0.0960155108, 0.0960155108],
+            [0.55, 0.0],
+            [0.0960155108, -0.0960155108],
+        ]
+    )
+
+    _, a, b, phi = ellipse_params_via_border_pca_from(border_grid=border_grid)
+
+    assert float(phi) == 0.0
+    assert float(a) == pytest.approx(0.55 + 1.0e-12)
+    assert float(b) == pytest.approx(0.55 + 1.0e-12)
+
+
+def test__ellipse_params__anisotropic_border_retains_pca_major_axis():
+    border_grid = np.array(
+        [
+            [-2.0, 0.0],
+            [0.0, 1.0],
+            [2.0, 0.0],
+            [0.0, -1.0],
+        ]
+    )
+
+    _, a, b, phi = ellipse_params_via_border_pca_from(border_grid=border_grid)
+
+    assert abs(float(phi)) == pytest.approx(np.pi / 2.0)
+    assert float(a) > float(b)
+


### PR DESCRIPTION
## Summary

- detect when the border covariance's PCA eigenvalues are equal within `sqrt(machine epsilon)` relative scale
- select a deterministic axis-aligned frame only in that near-isotropic case
- retain the ordinary PCA major axis for non-degenerate borders
- add regression coverage for the degenerate branch and its anisotropic control

PCA eigenvectors are mathematically undefined for equal eigenvalues. NumPy and JAX can choose different valid orientations; deriving maximum ellipse extents along those arbitrary axes made border relocation backend-dependent. The deterministic branch removes that ambiguity without changing the public interface.

## Evidence

The downstream full-`FitImaging` reproducer measured, before this fix:

- relocated source-grid error: `2.835e-1`
- mapping-matrix error: `1.492e-1`
- curvature-system error: `8.690e-3`
- reconstruction error: `8.989e-3`

With this patch applied locally at the worst one-ULP point:

- curvature-system error: `1.583e-16`
- data-vector error: `1.331e-16`
- reconstruction error: `8.202e-11`
- figure-of-merit error: exactly zero
- NumPy/JAX support masks: identical

## Validation

- 2 focused regression tests passed
- direct JAX `jit` and `vmap` round-trips passed with deterministic `phi=0`
- downstream NumPy/JAX full-likelihood parity reproducer passed
- GitHub's Python 3.12/3.13 full test matrix is the merge gate

## API Changes

None. No new configuration or public symbol.

## Numerical Behavior

Only near-isotropic border covariances enter the deterministic-axis branch. Non-degenerate PCA behavior and all NNLS settings/algorithms are unchanged.

## RED Gate Authorization

The user explicitly instructed this session to continue the work and merge each change once its CI is green. This PR will not be merged unless its own required checks succeed. No release is authorized or performed.

Closes #445