### PR TITLE
feat: [jax] extra becomes no-op alias, JAX default via autonerves (PyAutoLens#702)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,9 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    # Floor, not a pin. Without one, pip backtracking the extras chain
-    # (autoarray[jax] -> autonerves[jax]) may walk the release history to 2022:
-    # "version X does not provide the extra 'jax'" is a pip *warning*, not an
-    # error, so a pre-extras release is a legal solution. PyAutoLens#687.
+    # Floor, not a pin (PyAutoLens#687) — bump to the first release with JAX
+    # in autonerves' base dependencies once it exists (PyAutoLens#702), so
+    # backtracking cannot pair this autoarray with a jax-optional autonerves.
     "autonerves>=2026.7.29.2",
     "astropy>=5.0",
     "decorator>=4.0.0",
@@ -54,7 +53,11 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-jax = ["autonerves[jax]>=2026.7.29.2"]
+# JAX moved into autonerves' base dependencies (PyAutoLens#702). Kept as a
+# declared no-op so `pip install autoarray[jax]` keeps resolving
+# (PyAutoLens#687). The interferometer JAX extras (nufftax, tfp-nightly)
+# deliberately stay in `optional` — they are NOT part of the default install.
+jax = []
 optional = [
     "autoarray[jax]",
     "numba",


### PR DESCRIPTION
## Summary
Part of promoting JAX to a default dependency of the stack (PyAutoLens#702). autoarray receives JAX transitively through autonerves' base dependencies, so the only changes here are packaging metadata: the `[jax]` extra (previously `autonerves[jax]`) becomes a declared no-op alias (PyAutoLens#687), and the autonerves floor comment records the follow-up floor bump to the first promoted autonerves release. The interferometer JAX extras (`nufftax`, `pynufft`, `tfp-nightly`) deliberately stay in `[optional]` — they are NOT part of the default install.

## API Changes
None — packaging metadata only.
See full details below.

## Test Plan
- [x] pyproject parses; `[jax]` alias resolves
- [ ] No-JAX CI leg (PyAutoHeart lib-tests.yml `unittest-nojax`) green once the Heart PR merges

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `pip install autoarray` now installs JAX by default via the autonerves chain (except Intel macOS).

### Migration
- Before: `pip install autoarray[jax]`
- After: `pip install autoarray` (the `[jax]` form still works — no-op alias)

</details>

Part of the six-repo JAX-default-dependency change: PyAutoLens#702.

Generated by the PyAutoLabs agent workflow.
