### PR TITLE
refactor: defer nufftax/jax and numba imports to first use

### DIFF
--- a/autoarray/numba_util.py
+++ b/autoarray/numba_util.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+import threading
 
 from autonerves import conf
 
@@ -15,24 +17,61 @@ except Exception:
     parallel = False
 
 
-def jit(nopython=nopython, cache=cache, parallel=parallel, fastmath=False):
+# Decorated functions are queued here and only handed to numba on the first
+# call of any of them, keeping ``import numba`` off the library import path.
+# Materialization converts every queued function at once and rebinds the
+# defining module's global, because numba's nopython mode must resolve
+# cross-calls between decorated functions to real dispatchers at compile time.
+_pending = []
+_materialize_lock = threading.Lock()
 
-    def wrapper(func):
+
+def _materialize_all():
+    with _materialize_lock:
+        if not _pending:
+            return
 
         try:
-
             import numba
-
-            return numba.jit(
-                func,
-                nopython=nopython,
-                cache=cache,
-                parallel=parallel,
-                fastmath=fastmath,
-            )
-
         except ModuleNotFoundError:
+            numba = None
 
-            return func
+        while _pending:
+            func, options, placeholder, state = _pending.pop()
+
+            if numba is None:
+                target = func
+            else:
+                target = numba.jit(func, **options)
+
+            state["target"] = target
+
+            module = sys.modules.get(func.__module__)
+            if module is not None and getattr(module, func.__name__, None) is placeholder:
+                setattr(module, func.__name__, target)
+
+
+def jit(nopython=nopython, cache=cache, parallel=parallel, fastmath=False):
+    options = dict(
+        nopython=nopython,
+        cache=cache,
+        parallel=parallel,
+        fastmath=fastmath,
+    )
+
+    def wrapper(func):
+        import functools
+
+        state = {"target": None}
+
+        @functools.wraps(func)
+        def lazy(*args, **kwargs):
+            if state["target"] is None:
+                _materialize_all()
+            return state["target"](*args, **kwargs)
+
+        _pending.append((func, options, lazy, state))
+
+        return lazy
 
     return wrapper

--- a/autoarray/operators/transformer.py
+++ b/autoarray/operators/transformer.py
@@ -23,10 +23,29 @@ from autoarray.structures.arrays import array_2d_util
 from autoarray.operators import transformer_util
 
 
-try:
-    import nufftax as _nufftax
-except ModuleNotFoundError:
-    _nufftax = None
+# nufftax pulls in jax at import (~0.7s), which sessions that never touch an
+# interferometer transformer should not pay for — deferred to _load_nufftax(),
+# called from TransformerNUFFT's entry points (not only __init__, because
+# unpickled instances in multiprocessing workers never re-run __init__).
+_nufftax = None
+_nufftax_loaded = False
+
+
+def _load_nufftax():
+    global _nufftax, _nufftax_loaded
+    if _nufftax_loaded:
+        return _nufftax
+    _nufftax_loaded = True
+    try:
+        import nufftax
+    except ModuleNotFoundError:
+        return None
+    _nufftax = nufftax
+    _version = tuple(int(v) for v in _nufftax.__version__.split(".")[:2])
+    # Only the 0.6.x series both has the primitives module and needs the shim.
+    if (0, 6) <= _version < (0, 7):
+        _patch_nufftax_batchers()
+    return _nufftax
 
 
 def _patch_nufftax_batchers():
@@ -85,13 +104,6 @@ def _patch_nufftax_batchers():
         batching.primitive_batchers[prim] = guarded_batcher(
             prim, impl, source_idx, base_rank
         )
-
-
-if _nufftax is not None:
-    _version = tuple(int(v) for v in _nufftax.__version__.split(".")[:2])
-    # Only the 0.6.x series both has the primitives module and needs the shim.
-    if (0, 6) <= _version < (0, 7):
-        _patch_nufftax_batchers()
 
 
 def pynufft_exception():
@@ -643,7 +655,7 @@ class TransformerNUFFT:
         """
         from astropy import units
 
-        if _nufftax is None:
+        if _load_nufftax() is None:
             nufftax_exception()
 
         if chunk_size is not None and chunk_size <= 0:
@@ -685,6 +697,8 @@ class TransformerNUFFT:
         fixed-size chunks via ``jax.lax.scan`` (JAX path) or a Python loop
         (numpy path) — caps the nufftax gather-buffer allocation per call.
         """
+        _load_nufftax()
+
         K = int(self._x.shape[0])
 
         if xp.__name__.startswith("jax"):
@@ -789,6 +803,8 @@ class TransformerNUFFT:
         the sparse-operator dirty image is scale-consistent across all three
         transformers.
         """
+        _load_nufftax()
+
         n_y, n_x = self.real_space_mask.shape_native
         n_modes = (n_x, n_y)  # nufftax wants (n1, n2) = (N_x, N_y)
         K = int(self._x.shape[0])
@@ -860,6 +876,8 @@ class TransformerNUFFT:
         ``n_src`` separate NUFFT invocations and blow up the JIT graph
         for pixelization-heavy fits (notably double-source-plane).
         """
+        _load_nufftax()
+
         n_src = mapping_matrix.shape[1]
         rows, cols = self.real_space_mask.slim_to_native_tuple
         n_y, n_x = self.real_space_mask.shape_native


### PR DESCRIPTION
## Summary
Defers PyAutoArray's two heavy import-time costs to first use, as part of the cross-repo import-time task (PyAutoFit#1505): the nufftax import (which pulls jax, ~0.7s) and numba jit decoration (~0.2s). `import autoarray` drops to ~1.15s with neither jax, nufftax nor numba loading on bare import.

- `operators/transformer.py`: the module-level `import nufftax` and the version-gated 0.6.x batcher shim move into an idempotent `_load_nufftax()`, called from `TransformerNUFFT.__init__` **and** the three methods that dereference the module global (`_forward_native`, `image_from`, `transform_mapping_matrix`) — instances unpickled in multiprocessing workers never re-run `__init__`, so the method anchors are load-bearing.
- `numba_util.py`: `jit()` queues functions and hands them to numba on the first call of any decorated function, rebinding each defining module's global to the real dispatcher so nopython cross-calls (5 exist) still resolve at compile time. `ModuleNotFoundError → plain function` fallback preserved; config-driven nopython/cache/parallel options unchanged.

## API Changes
None — internal changes only. All 29 `@numba_util.jit()` functions and `TransformerNUFFT` behave identically; laziness only moves when the underlying imports happen.
See full details below.

## Test Plan
- [x] Full suite: 1062 passed
- [x] `TransformerNUFFT` numpy/jax visibilities agree exactly; `transform_mapping_matrix` + `image_from` verified; pickled-instance-with-reset-module-state (worker simulation) works
- [x] numba cross-call path (`binned_mask_from` → `binned_image_from`) compiles and runs; module global rebinds to `CPUDispatcher`
- [x] Downstream autogalaxy (1111) and autolens (538) suites green against this branch

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autoarray.numba_util.jit` — decorated functions are lightweight wrappers until first call (then real numba dispatchers, module globals rebound). Dispatcher-only attributes (e.g. `.py_func`) are unavailable before first call; no users exist in the organism.
- `autoarray.operators.transformer` — `nufftax` (and jax via it) import on first `TransformerNUFFT` use instead of at module import; a missing nufftax now errors at construction (same `nufftax_exception()`), not silently at import.

### Migration
- None required.

</details>

Generated by the PyAutoLabs agent workflow.
