### PR TITLE
build: floor autonerves at 2026.8.23.1 for the SMALLDAT regime stamp

### DIFF
--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -8,10 +8,10 @@ SMALL_DATASETS_PIXEL_SCALES = 0.6
 
 # The FITS header card ``autonerves.fitsable.stamp_small_datasets_regime`` writes
 # on every array the stack outputs. Deliberately duplicated here rather than
-# imported: ``pyproject.toml`` floors autonerves at a release that predates the
-# stamp, so an import would hard-fail against a legitimately-resolved older
-# autonerves. Reading the card by name degrades to "absent" instead, which is
-# exactly the fallback path below. Keep in sync with PyAutoNerves#153.
+# imported even though ``pyproject.toml`` now floors autonerves at the first
+# stamped release: the card name is an on-disk format detail, and keeping the
+# reader independent of the writer's Python API preserves the safe "absent"
+# fallback if that API moves. Keep in sync with PyAutoNerves#153.
 SMALL_DATASETS_HEADER_KEY = "SMALLDAT"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,14 @@ dependencies = [
     # Floor, not a pin (PyAutoLens#687) — bump to the first release with JAX
     # in autonerves' base dependencies once it exists (PyAutoLens#702), so
     # backtracking cannot pair this autoarray with a jax-optional autonerves.
-    "autonerves>=2026.8.22.1",
+    #
+    # It ALSO floors the SMALLDAT regime stamp (PyAutoNerves#153/#154), first
+    # released in 2026.8.23.1. Below that release autonerves' FITS writer emits
+    # no card at all, so should_simulate reads the regime as "unknown" and falls
+    # back to the shape heuristic -- which cannot see capped interferometer
+    # datasets, the case the stamp exists for. Both reasons are load-bearing:
+    # neither replaces the other, so do not drop either when next bumping.
+    "autonerves>=2026.8.23.1",
     "astropy>=5.0",
     "decorator>=4.0.0",
     "dill>=0.3.1.1",


### PR DESCRIPTION
Bumps `autoarray`'s floor from `autonerves>=2026.8.22.1` to `>=2026.8.23.1`.

## Why

`2026.8.22.1` was the newest release on PyPI but **predates the SMALLDAT regime stamp** (PyAutoNerves#153/#154). A PyPI-installed `autoarray` resolved an `autonerves` whose FITS writer emits no card at all, so `should_simulate` read the regime as "unknown" and fell back to the shape heuristic — which cannot see capped interferometer datasets, the case the stamp exists for.

Nothing was broken by that; it is the designed degradation. But the stamp was **inert** for anyone installing rather than running from a checkout. `2026.8.23.1` (nerves `0ecefa0`) is the first release carrying it.

## Verification

Checked against the **published wheel** in a clean venv with `PYTHONPATH` stripped, not the source tree:

```
autonerves 2026.8.23.1 (site-packages, no source leak)
PYAUTO_SMALL_DATASETS=1 -> SMALLDAT = True   (type: bool)
PYAUTO_SMALL_DATASETS=0 -> SMALLDAT = False  (type: bool)
keyword length <= 8: True
```

A genuine FITS boolean, not a string — `bool("F")` is `True` in Python, so a coerced string card would invert the regime.

## Deliberately unchanged

- **The shape fallback** in `should_simulate`, and `_is_capped_at_the_current_cap` on the capped branch. The floor governs what a fresh install *writes*; it says nothing about datasets already on disk, every one of which is unstamped. Those fallbacks protect them.
- **The `PyAutoLens#687/#702` comment.** That explains a different historical reason for this floor (JAX moving into autonerves' base deps). Both reasons are load-bearing, so the stamp reason was *added*, not substituted — and the comment now says so explicitly.
- **The duplicated `"SMALLDAT"` literal** in `dataset_util`. Importing it from autonerves becomes safe now the floor names a stamped release, but the duplication is documented and a stale reader degrades to the fallback, which is the safe direction. Converting it is optional and low value.

Closes the follow-up filed as `PyAutoMind/draft/maintenance/libraries/bump_autoarray_autonerves_floor_after_stamp_release.md`.