### PR TITLE
fix: widen scalar pixel_scales / shape_native at the two sites #464 missed

### DIFF
--- a/autoarray/geometry/geometry_util.py
+++ b/autoarray/geometry/geometry_util.py
@@ -7,16 +7,25 @@ from autoarray import validate
 
 def convert_shape_native_1d(shape_native: Union[int, Tuple[int]]) -> Tuple[int]:
     """
-    Convert an input `shape_native` of type `int` to a tuple `(int,)`. If the input is already a
-    `(int,)` tuple it is returned unchanged.
+    Convert an input `shape_native` given as a single integer scalar to a tuple `(int,)`. If
+    the input is already a `(int,)` tuple it is returned unchanged.
 
     This enables users to input `shape_native` as a single integer value and have the type
     automatically normalised to `(int,)` which is used internally by 1D data structures.
 
+    Any concrete integer scalar is widened — `int` and `np.integer` — not just an exact `int`.
+    An `np.integer` is what indexing a shape tuple or reading a FITS header returns, so it
+    reaches this function on paths a user would consider ordinary. The widened value is cast
+    to a Python `int`, so the tuple this returns is always `(int,)` regardless of what went in.
+
+    A `float` is deliberately *not* widened: `shape_native` counts pixels, so a non-integer is
+    a mistake worth surfacing rather than one to normalise away. Neither is a `bool`, nor a JAX
+    tracer — see :func:`autoarray.validate.is_concrete_integer`.
+
     Parameters
     ----------
     shape_native
-        The 1D shape to convert, either as a plain `int` or a 1-element tuple `(int,)`.
+        The 1D shape to convert, either as a plain integer scalar or a 1-element tuple `(int,)`.
 
     Returns
     -------
@@ -24,8 +33,8 @@ def convert_shape_native_1d(shape_native: Union[int, Tuple[int]]) -> Tuple[int]:
         The shape as a 1-element tuple `(int,)`.
     """
 
-    if type(shape_native) is int:
-        shape_native = (shape_native,)
+    if validate.is_concrete_integer(shape_native):
+        shape_native = (int(shape_native),)
 
     return shape_native
 

--- a/autoarray/mask/mask_1d.py
+++ b/autoarray/mask/mask_1d.py
@@ -10,6 +10,7 @@ from autoarray.mask.abstract_mask import Mask
 
 from autoarray.mask.derive.grid_1d import DeriveGrid1D
 from autoarray.mask.derive.mask_1d import DeriveMask1D
+from autoarray.geometry import geometry_util
 from autoarray.geometry.geometry_1d import Geometry1D
 from autoarray.structures.abstract_structure import Structure
 from autoarray.structures.arrays import array_1d_util
@@ -68,8 +69,7 @@ class Mask1D(Mask):
         if invert:
             mask = ~mask
 
-        if type(pixel_scales) is float:
-            pixel_scales = (pixel_scales,)
+        pixel_scales = geometry_util.convert_pixel_scales_1d(pixel_scales=pixel_scales)
 
         if len(mask.shape) != 1:
             raise exc.MaskException("The input mask is not a one dimensional array")

--- a/autoarray/validate.py
+++ b/autoarray/validate.py
@@ -70,6 +70,29 @@ def is_concrete_scalar(value: Any) -> bool:
     return isinstance(value, (int, float, np.integer, np.floating))
 
 
+def is_concrete_integer(value: Any) -> bool:
+    """
+    Returns ``True`` if ``value`` is a concrete Python or NumPy **integer** scalar.
+
+    The integer-only counterpart of :func:`is_concrete_scalar`, for parameters which
+    count pixels rather than measure them — a ``shape_native`` of ``5.0`` is a mistake
+    worth surfacing, not a value to silently widen, so a ``float`` returns ``False``
+    here where ``is_concrete_scalar`` would accept it.
+
+    Tracer-safety and the ``bool`` exclusion carry over from
+    :func:`is_concrete_scalar` unchanged.
+
+    Parameters
+    ----------
+    value
+        The value to test.
+    """
+    if isinstance(value, bool):
+        return False
+
+    return isinstance(value, (int, np.integer))
+
+
 def _raise(
     name: str,
     rule: str,

--- a/test_autoarray/geometry/test_geometry_util.py
+++ b/test_autoarray/geometry/test_geometry_util.py
@@ -21,18 +21,25 @@ def test__convert_pixel_scales_1d__widens_any_real_scalar(pixel_scales):
     """
     Any concrete real scalar widens, not just an exact `float`. `int` is what a user types by
     hand; `np.floating` is what indexing an array or reading a FITS header returns.
+
+    The tuple-ness is asserted before the value: `np.float64(1.0) == (1.0,)` NumPy-broadcasts
+    to `array([True])`, which is truthy, so a value-only assertion passes on the unwidened
+    scalar and tests nothing.
     """
-    assert aa.util.geometry.convert_pixel_scales_1d(pixel_scales=pixel_scales) == (1.0,)
+    pixel_scales = aa.util.geometry.convert_pixel_scales_1d(pixel_scales=pixel_scales)
+
+    assert type(pixel_scales) is tuple
+    assert pixel_scales == (1.0,)
 
 
 @pytest.mark.parametrize(
     "pixel_scales", [1, 1.0, np.float64(1.0), np.int32(1), np.float32(1.0)]
 )
 def test__convert_pixel_scales_2d__widens_any_real_scalar(pixel_scales):
-    assert aa.util.geometry.convert_pixel_scales_2d(pixel_scales=pixel_scales) == (
-        1.0,
-        1.0,
-    )
+    pixel_scales = aa.util.geometry.convert_pixel_scales_2d(pixel_scales=pixel_scales)
+
+    assert type(pixel_scales) is tuple
+    assert pixel_scales == (1.0, 1.0)
 
 
 @pytest.mark.parametrize("pixel_scales", [1, np.float64(1.0), np.int32(1)])
@@ -84,6 +91,64 @@ def test__convert_pixel_scales__a_bool_is_not_treated_as_a_scalar():
     """
     assert aa.util.geometry.convert_pixel_scales_1d(pixel_scales=True) is True
     assert aa.util.geometry.convert_pixel_scales_2d(pixel_scales=True) is True
+
+
+@pytest.mark.parametrize("shape_native", [5, np.int32(5), np.int64(5)])
+def test__convert_shape_native_1d__widens_any_integer_scalar(shape_native):
+    """
+    Any concrete integer scalar widens, not just an exact `int`. An `np.integer` is what
+    indexing a shape tuple or reading a FITS header returns, and `Array1D.full` then does
+    `shape_native[0]` on whatever comes back — a bare scalar raised `IndexError` there.
+
+    The tuple-ness is asserted before the value: `np.int32(5) == (5,)` NumPy-broadcasts to
+    `array([True])`, which is truthy, so a value-only assertion passes on the unwidened
+    scalar and tests nothing.
+    """
+    shape_native = aa.util.geometry.convert_shape_native_1d(shape_native=shape_native)
+
+    assert type(shape_native) is tuple
+    assert shape_native == (5,)
+
+
+@pytest.mark.parametrize("shape_native", [5, np.int32(5), np.int64(5)])
+def test__convert_shape_native_1d__widened_entry_is_a_python_int(shape_native):
+    """
+    The widened value is cast, so a NumPy scalar never reaches the shape stored on a
+    structure. `5 == np.int32(5)` in Python, so the cast has to be asserted on the type.
+    """
+    (entry,) = aa.util.geometry.convert_shape_native_1d(shape_native=shape_native)
+    assert type(entry) is int
+
+
+def test__convert_shape_native_1d__a_float_is_not_widened():
+    """
+    Unlike `pixel_scales`, `shape_native` counts pixels rather than measuring them, so a
+    `float` is a mistake worth surfacing rather than one to normalise away — the predicate
+    here is `is_concrete_integer`, not `is_concrete_scalar`.
+    """
+    assert aa.util.geometry.convert_shape_native_1d(shape_native=5.0) == 5.0
+
+
+def test__convert_shape_native_1d__a_bool_is_not_treated_as_a_scalar():
+    """`bool` is a subclass of `int`, but `True` reaching a pixel count is a different mistake."""
+    assert aa.util.geometry.convert_shape_native_1d(shape_native=True) is True
+
+
+def test__convert_shape_native_1d__tuple_input_is_returned_unchanged():
+    shape_native = (5,)
+    assert (
+        aa.util.geometry.convert_shape_native_1d(shape_native=shape_native)
+        is shape_native
+    )
+
+
+def test__convert_shape_native_1d__a_tracer_passes_through_untouched():
+    """Inside a `jax.jit` the value is traced; widening it would resolve it to a bool."""
+    tracer_like = _NotAConcreteScalar()
+
+    assert (
+        aa.util.geometry.convert_shape_native_1d(shape_native=tracer_like) is tracer_like
+    )
 
 
 def test__central_pixel_coordinates_1d_from():

--- a/test_autoarray/mask/test_mask_1d.py
+++ b/test_autoarray/mask/test_mask_1d.py
@@ -55,6 +55,47 @@ def test__constructor__input_is_2d_mask__raises_exception():
         aa.Mask1D(mask=[[False, False, True]], pixel_scales=1.0)
 
 
+@pytest.mark.parametrize(
+    "pixel_scales", [1, 1.0, np.float64(1.0), np.int32(1), np.float32(1.0)]
+)
+def test__constructor__widens_any_real_scalar_pixel_scales(pixel_scales):
+    """
+    `Mask1D` hand-rolled its own `type(pixel_scales) is float` check and never routed through
+    `convert_pixel_scales_1d`, so an `int` or a NumPy scalar was stored bare. `Mask2D` already
+    went through the chokepoint — this closed the 1D/2D divergence.
+    """
+    mask = aa.Mask1D(mask=[False, False, True], pixel_scales=pixel_scales)
+
+    assert mask.pixel_scales == (1.0,)
+    assert type(mask.pixel_scales[0]) is float
+
+
+def test__constructor__scalar_pixel_scales__geometry_is_usable():
+    """
+    The bare scalar only surfaced later, when geometry subscripted it:
+    `TypeError: 'int' object is not subscriptable`, naming nothing the caller passed.
+    """
+    mask = aa.Mask1D(mask=[False, False, True], pixel_scales=1)
+
+    assert mask.geometry.scaled_maxima == (1.5,)
+
+
+def test__constructor__tuple_pixel_scales_returned_unchanged():
+    mask = aa.Mask1D(mask=[False, False, True], pixel_scales=(1.0,))
+
+    assert mask.pixel_scales == (1.0,)
+
+
+@pytest.mark.parametrize("pixel_scales", [0, 0.0, -1, -1.0, float("nan")])
+def test__constructor__invalid_pixel_scales__raises_exception(pixel_scales):
+    """
+    Routing through `convert_pixel_scales_1d` brings `validate.validate_pixel_scales` with it,
+    so `Mask1D` now rejects what `Mask2D` already rejected. A deliberate contract change.
+    """
+    with pytest.raises(ValueError):
+        aa.Mask1D(mask=[False, False, True], pixel_scales=pixel_scales)
+
+
 # ---------------------------------------------------------------------------
 # is_all_true / is_all_false — parametrized
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PyAutoArray#464 (`8298d74e`) replaced `type(x) is float` with `validate.is_concrete_scalar`
in `convert_pixel_scales_1d` / `convert_pixel_scales_2d`. Re-running that prompt's repro
found the sweep did not reach every site of the same defect. Two were still live on `main`,
both reproduced before being touched:

- **`Mask1D.__init__`** hand-rolled its own widening and never routed through
  `convert_pixel_scales_1d`, so it still carried the original exact-type check.
  `Mask1D(mask=…, pixel_scales=1)` stored the bare `1`, and geometry then raised
  `TypeError: 'int' object is not subscriptable` — #464's exact reported symptom, on a
  public constructor. `Mask2D.__init__` already called `convert_pixel_scales_2d`, so this
  was a 1D/2D divergence rather than a design choice.
- **`convert_shape_native_1d`** kept `type(shape_native) is int`, which `8298d74e` listed
  as not-fixed-there. `Array1D.full` is its sole caller and does `shape_native[0]` on the
  result, so `Array1D.full(shape_native=np.int32(5))` raised
  `IndexError: invalid index to scalar variable`.

Closes #484.

## API Changes

`Mask1D` now widens any concrete real scalar `pixel_scales` (`int`, `np.integer`,
`np.floating`) to `(float,)`, where previously only an exact `float` was widened and
anything else was stored bare. Routing it through the shared chokepoint also brings
`validate.validate_pixel_scales` with it, so `Mask1D` now **rejects** `0`, negative and
`nan` pixel scales — a deliberate contract change that makes it match `Mask2D`, which
already rejected them. `convert_shape_native_1d` likewise widens any concrete integer
scalar and casts to a Python `int`. One new public predicate, `validate.is_concrete_integer`.
No symbol was removed or renamed, and no signature changed.
See full details below.

## Test Plan

- [x] Full `test_autoarray` suite: **1201 passed, 0 failed**. The 3 pre-existing pynufft
      failures `8298d74e` baselined no longer occur, so there was nothing to baseline against.
- [x] Every new assertion claiming regression coverage confirmed to **fail without the
      source change**. The boundary tests (tuple returned unchanged, `float`/`bool` not
      widened, tracer passthrough) pass either way by design, mirroring those #464 shipped.
- [x] Real-JAX check: `jax.jit` compiles and runs with a traced `pixel_scales`, which passes
      through untouched — both functions stay `jit`-safe.
- [x] Downstream blast radius: PyAutoGalaxy and PyAutoLens only re-export `Mask1D` and
      construct none; neither uses `Array1D.full` / `zeros` / `ones`.

```
Mask1D(mask=…, pixel_scales=1).pixel_scales          -> (1.0,)      # was 1
…that mask's .geometry.scaled_maxima                 -> (1.5,)      # was TypeError
Array1D.full(fill_value=1.0, shape_native=np.int32(5)) builds       # was IndexError
Mask1D(…, pixel_scales=0 / -1 / nan)                 -> ValueError  # new, matches Mask2D
```

### Test-quality fix included

#464's own widening tests asserted value only, and `np.float64(1.0) == (1.0,)`
NumPy-broadcasts to `array([True])`, which is truthy — so they passed on an unwidened NumPy
scalar and tested nothing. Four of six parametrisations were vacuous. They now assert
tuple-ness before the value, confirmed by reverting to the pre-#464 source and watching them
fail. The new tests here assert the same way for the same reason.

### Not fixed here

Tuple entries are still returned unnormalised: `convert_pixel_scales_2d((1, 1))` keeps its
ints and contradicts the `Tuple[float, float]` annotation. It alters return values on paths
that work today, so it needs its own change and its own suite read.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autoarray.validate.is_concrete_integer(value)` — `True` for a concrete Python or NumPy
  **integer** scalar. The integer-only counterpart of `is_concrete_scalar`, for parameters
  which count pixels rather than measure them: a `float` returns `False` here where
  `is_concrete_scalar` accepts it. `bool` exclusion and tracer-safety carry over unchanged.

### Changed Behaviour
- `autoarray.Mask1D.__init__` — `pixel_scales` given as any concrete real scalar (`int`,
  `np.integer`, `np.floating`) is now widened to `(float,)`. Previously only an exact
  `float` was widened; anything else was stored bare and raised
  `TypeError: 'int' object is not subscriptable` on first geometry use.
- `autoarray.Mask1D.__init__` — now raises `ValueError` for `pixel_scales` of `0`, a
  negative number, or `nan`, in both scalar and tuple form. Previously accepted silently.
  This matches `Mask2D`, which already validated.
- `autoarray.util.geometry.convert_shape_native_1d` — `shape_native` given as any concrete
  integer scalar (`int`, `np.integer`) is now widened to `(int,)` and cast to a Python
  `int`. Previously only an exact `int` was widened; an `np.integer` fell through and
  `Array1D.full` / `zeros` / `ones` raised `IndexError: invalid index to scalar variable`.
  A `float` is still deliberately **not** widened.

### Removed
None.

### Renamed
None.

### Changed Signature
None.

### Migration
No migration required — all three changes accept strictly more input than before, except
the `Mask1D` validation, which rejects pixel scales that were already unusable:

- Before: `Mask1D(mask=…, pixel_scales=0.0)` constructed, then produced a division by zero
  in every pixel-to-scaled conversion.
- After: `Mask1D(mask=…, pixel_scales=0.0)` raises `ValueError` naming the parameter and
  the received value.

</details>

Generated by the PyAutoLabs agent workflow.
