### PR TITLE
fix: correct mirrored row weights + round-off-dependent cells in rectangular mapper

### DIFF
--- a/autoarray/inversion/mesh/interpolator/rectangular.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular.py
@@ -544,11 +544,23 @@ def adaptive_rectangular_mappings_weights_via_interpolation_from(
     grid_over_sampled_transformed = transform_func(grid_over_sampled_scaled)
     grid_over_index = (source_grid_size - 3) * grid_over_sampled_transformed + 1
 
-    # --- Step 4. Floor/ceil indices ---
-    ix_down = xp.floor(grid_over_index[:, 0])
-    ix_up = xp.ceil(grid_over_index[:, 0])
-    iy_down = xp.floor(grid_over_index[:, 1])
-    iy_up = xp.ceil(grid_over_index[:, 1])
+    # --- Step 4. Bracketing indices ---
+    #
+    # `ix_up` is ALWAYS `ix_down + 1`, never `ceil(grid_over_index)`.
+    # `transform()` ends in `xp.clip(F_q, 0.0, 1.0)`, so saturated points land
+    # on EXACTLY integer `grid_over_index` values. Under `ceil` the bracketing
+    # cell collapses there (`ix_up == ix_down`) and the interpolation weight is
+    # forced onto a single row; a 1-ULP change in the traced grid then moves
+    # such a point off the plateau and jumps its weight a whole mesh row. That
+    # is a discontinuity in the discretisation, and it is what made the eager
+    # and jitted likelihoods disagree by ~1.6e-3 on an otherwise smooth
+    # surface (autolens_workspace_test#279). Bracketing with `ix_down + 1` is
+    # continuous at integer coordinates, so the cell assignment no longer
+    # depends on round-off. Clamp so the `+ 1` cannot leave the mesh.
+    ix_down = xp.clip(xp.floor(grid_over_index[:, 0]), 0, source_grid_size - 2)
+    iy_down = xp.clip(xp.floor(grid_over_index[:, 1]), 0, source_grid_size - 2)
+    ix_up = ix_down + 1
+    iy_up = iy_down + 1
 
     # --- Step 5. Four corners ---
     idx_tl = xp.stack([ix_up, iy_down], axis=1)
@@ -570,13 +582,20 @@ def adaptive_rectangular_mappings_weights_via_interpolation_from(
     )
 
     # --- Step 7. Bilinear interpolation weights ---
-    t_row = (grid_over_index[:, 0] - ix_down) / (ix_up - ix_down + 1e-12)
-    t_col = (grid_over_index[:, 1] - iy_down) / (iy_up - iy_down + 1e-12)
+    #
+    # `t_row` / `t_col` are fractional distances measured FROM the `down` node,
+    # so the `up` node carries `t` and the `down` node carries `1 - t`. The row
+    # weights were previously the other way round (`ix_up` carried `1 - t_row`,
+    # `ix_down` carried `t_row`), mirroring the interpolation in the row
+    # direction; the column weights were, and remain, correctly paired. No
+    # `+ 1e-12` guard is needed now the bracket is always exactly one cell wide.
+    t_row = grid_over_index[:, 0] - ix_down
+    t_col = grid_over_index[:, 1] - iy_down
 
-    w_tl = (1 - t_row) * (1 - t_col)
-    w_tr = (1 - t_row) * t_col
-    w_bl = t_row * (1 - t_col)
-    w_br = t_row * t_col
+    w_tl = t_row * (1 - t_col)
+    w_tr = t_row * t_col
+    w_bl = (1 - t_row) * (1 - t_col)
+    w_br = (1 - t_row) * t_col
     weights = xp.stack([w_tl, w_tr, w_bl, w_br], axis=1)
 
     return flat_indices, weights

--- a/test_autoarray/inversion/pixelization/interpolator/test_rectangular.py
+++ b/test_autoarray/inversion/pixelization/interpolator/test_rectangular.py
@@ -293,6 +293,111 @@ def test__mappings_sizes_weights__shapes_and_weight_normalization():
     assert np.allclose(w.sum(axis=1), 1.0, atol=1e-10)
 
 
+def _index_space_nodes(idx, n):
+    """
+    Recover each mapped pixel's (row, col) position in index space.
+
+    Inverse of the module's ``flatten(ix, iy) = (n - ix) * n + iy``.
+    """
+    return n - idx // n, idx % n
+
+
+def test__mappings_sizes_weights__reproduces_the_query_position():
+    """
+    Bilinear interpolation must be exact for linear functions, which means the
+    four weights have to reconstruct the query itself:
+
+        sum_i w_i * node_i == grid_over_index
+
+    Partition of unity alone does NOT imply this — it is satisfied by any
+    consistent mis-pairing of corners to weights, which is exactly how the row
+    weights came to be mirrored (`ix_up` carrying `1 - t_row` instead of
+    `t_row`) and stayed that way from 2025-09-23 to 2026-08-26. The mirroring
+    was smooth, so gradient checks passed; only this property catches it.
+    See autolens_workspace_test#279.
+    """
+    n = 16
+    data_grid, over, weights = _seeded_inputs(seed=11)
+
+    idx, w = adaptive_rectangular_mappings_weights_via_interpolation_from(
+        source_grid_size=n,
+        data_grid=data_grid,
+        data_grid_over_sampled=over,
+        mesh_weight_map=weights,
+        xp=np,
+    )
+
+    # Rebuild the index-space query the function discretises internally.
+    mu, scale = data_grid.mean(axis=0), data_grid.std(axis=0)
+    transform_func, _ = create_transforms(
+        (data_grid - mu) / scale, mesh_pixels=n, mesh_weight_map=weights, xp=np
+    )
+    grid_over_index = (n - 3) * transform_func((over - mu) / scale) + 1
+
+    node_row, node_col = _index_space_nodes(idx, n)
+
+    assert np.allclose(w.sum(axis=1), 1.0, atol=1e-10)
+    assert np.allclose((w * node_row).sum(axis=1), grid_over_index[:, 0], atol=1e-10)
+    assert np.allclose((w * node_col).sum(axis=1), grid_over_index[:, 1], atol=1e-10)
+
+
+def test__mappings_sizes_weights__cell_assignment_is_continuous_at_integers():
+    """
+    ``transform()`` ends in ``clip(F_q, 0.0, 1.0)``, so saturated queries land on
+    EXACTLY integer ``grid_over_index`` values — systematically, not by chance.
+    Bracketing those with ``ceil`` collapsed the cell (``ix_up == ix_down``), so
+    a 1-ULP move off the plateau jumped a point's weight a whole mesh row. That
+    made the likelihood depend on floating-point association, which is how the
+    eager and jitted evaluations came to disagree by ~1.6e-3.
+
+    Here the property is asserted directly on the interpolated value of a linear
+    ramp: approaching an integer row coordinate from either side must converge
+    to the value AT that coordinate.
+    """
+    n = 16
+    data_grid, _, weights = _seeded_inputs(seed=12)
+    mu, scale = data_grid.mean(axis=0), data_grid.std(axis=0)
+
+    transform_func, inv = create_transforms(
+        (data_grid - mu) / scale, mesh_pixels=n, mesh_weight_map=weights, xp=np
+    )
+
+    def interpolated_ramp(over):
+        idx, w = adaptive_rectangular_mappings_weights_via_interpolation_from(
+            source_grid_size=n,
+            data_grid=data_grid,
+            data_grid_over_sampled=over,
+            mesh_weight_map=weights,
+            xp=np,
+        )
+        node_row, node_col = _index_space_nodes(idx, n)
+        # A linear function of position; bilinear interpolation reproduces it
+        # exactly, so any discontinuity here is a cell-assignment jump.
+        return (w * (3.0 * node_row - 2.0 * node_col)).sum(axis=1)
+
+    # Sweep the row coordinate densely across the whole data range. In index
+    # space that spans [1, n - 2], so the sweep crosses every interior integer
+    # boundary; a jump at any crossing is a cell-assignment discontinuity.
+    # This is deliberately placement-free — the inverse transform is a knot
+    # lookup and cannot land a query on an integer precisely enough to probe
+    # one boundary directly.
+    lo, hi = data_grid[:, 0].min(), data_grid[:, 0].max()
+    sweep = np.stack(
+        [np.linspace(lo, hi, 20001), np.full(20001, np.median(data_grid[:, 1]))],
+        axis=1,
+    )
+
+    values = interpolated_ramp(sweep)
+    steps = np.abs(np.diff(values))
+
+    # The ramp must actually vary, or continuity is vacuous.
+    assert values.max() - values.min() > 1.0
+
+    # A whole-row flip moves the ramp by ~3.0 (its row coefficient); a
+    # continuous scheme moves by ~the sweep resolution.
+    assert steps.max() < 0.05
+
+
 # ---------------------------------------------------------------------------
 # Areas
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the bilinear mapper shared by every **adaptive** rectangular mesh. Found while diagnosing autolens_workspace_test#279 (an eager/jit likelihood divergence three repos away).

⚠️ **This changes reconstructions.** See "Behaviour change" below — downstream constants need regenerating, and this must merge before the workspace PRs that regenerate them.

## The two defects

`adaptive_rectangular_mappings_weights_via_interpolation_from` (`autoarray/inversion/mesh/interpolator/rectangular.py`):

**1. Mirrored row weights.** `t_row` is the fractional distance measured *from* `ix_down`, so `ix_up` must carry `t_row` and `ix_down` must carry `1 - t_row`. They were the other way round. The column weights were, and remain, correctly paired — only the rows were mirrored.

**2. Round-off-dependent cell assignment.** `ix_up = ceil(g)` collapses onto `ix_down` wherever `g` is exactly integral. `transform()` ends in `clip(F_q, 0.0, 1.0)`, so saturated points land on exactly integer `g` **systematically, not by chance**. There the bracketing cell degenerated and `t_row` was forced to 0 by the `+ 1e-12` guard; a 1-ULP change in the traced grid moved a point off the plateau and jumped its weight a whole mesh row.

(2) is why the eager and jitted likelihoods disagreed by ~1.6e-3 on an otherwise smooth surface. (1) is why (2) could not be fixed without a behaviour change.

## Evidence

A correct bilinear scheme must satisfy partition of unity **and** reproduce the query position (`sum_i w_i * node_i == g`). Partition of unity alone is satisfied by any *consistent* mis-pairing — which is exactly what was happening:

| version | date | partition | row err | col err | |
|---|---|---|---|---|---|
| `fd11b178` original | 2025-06-24 | 1.1e-16 | **0.000000** | **0.000000** | correct |
| `8f007957` adaptive fork | 2025-09-15 | 1.1e-16 | 0.000000 | **0.999884** | columns mirrored |
| `9b1c91cf` current | 2025-09-23 | 2.2e-16 | **0.999968** | 0.000000 | rows mirrored |
| this PR | — | 1.1e-16 | **0.000000** | **0.000000** | correct |

## Interpolation-accuracy census (the decisive evidence)

Likelihood at a fixed model is a **poor** discriminator here, and that is much of why this survived: with a pixelized source the inversion *solves* for the source values, so a mirrored mapping is still a valid linear basis over the same mesh pixels — merely mislabelled about *where* the flux sits. It can fit the data comparably well while being geometrically wrong.

So this was measured directly instead: interpolate a known function through the real mesh geometry and compare against ground truth, querying where the traced points actually are (an adaptive mesh must not be judged in regions it deliberately leaves coarse). Max error, `RectangularUniform`'s known-correct mapper as control:

| mesh | function | n=8 | n=16 | n=32 | n=64 |
|---|---|---|---|---|---|
| Bilinear (rank) **before** | smooth | 0.8187 | 0.4416 | 0.2444 | 0.1266 |
| Bilinear (rank) **after** | smooth | 0.4357 | 0.2835 | 0.0489 | **0.0260** |
| RTU (kernel) **before** | smooth | 0.7635 | 0.3793 | 0.1871 | 0.1068 |
| RTU (kernel) **after** | smooth | 0.3608 | 0.1838 | 0.0095 | **0.0034** |
| RTU (kernel) **before** | linear | 9.5816 | 7.2794 | 1.3158 | 0.6241 |
| RTU (kernel) **after** | linear | 2.9737 | 1.0731 | 0.0848 | **0.0229** |

The fix is better at **every mesh size, for both transforms, on both functions**. At n=64 it is ~4.9x more accurate for Bilinear and **~27-31x** for RTU. RTU is the *largest* beneficiary, so there is no compensating flip that made the old behaviour accidentally right for the kernel-CDF meshes.

Control (`RectangularUniform`, untouched by this PR) converges cleanly at ~O(h²) — 0.0979 → 0.0217 → 0.0052 → 0.0013 — confirming the harness measures what it claims.

## Both defects are regressions

The mapper was **correct when introduced** in `fd11b178` (2025-06-24): `clip(floor(f), 0, N-2)`, `ix + 1` rather than `ceil`, each corner given its own weight.

`8f007957` (2025-09-15, "adpative stuff implemented") forked it for the adaptive meshes with `ceil` and a `delta_up`/`delta_down` form — mirroring the columns, and dropping exactly-integer points entirely (no `1e-12` guard then, so all four weights were exactly zero). `9b1c91cf` (2025-09-23, "fixed mappings and weights") then fixed the columns and the dropped-point bug **and broke the rows**.

**The correct formulation never left the package.** It survives verbatim for the uniform mesh at `autoarray/inversion/mesh/interpolator/rectangular_uniform.py:72-99` and scores 0.000000 on both axes today. This PR restores that sibling's scheme rather than inventing one — which is also why `RectangularUniform` passes the eager/jit guard while the adaptive meshes fail.

## Affected meshes

All inherit `interpolator_cls` → `InterpolatorRectangular` from `RectangularRTUAdaptDensity`:

- `RectangularRTUAdaptDensity` (kernel-CDF, density-adapted)
- `RectangularRTUAdaptImage` (kernel-CDF, image-adapted)
- `RectangularBilinearAdaptDensity` (rank-CDF)
- `RectangularBilinearAdaptImage` (rank-CDF)

**Not affected** — different interpolators: `RectangularUniform`, `Delaunay`, `DelaunayNN`, `KNearestNeighbor`, `KNNBarycentric`.

## Regression tests

The bug survived eleven months and a "fix" commit because nothing asserted the interpolation property itself. Two tests added, both of which **fail on the previous implementation** and pass here:

- `test__mappings_sizes_weights__reproduces_the_query_position` — partition of unity plus linear reproduction. Fails previously by ~1.0 in the row axis.
- `test__mappings_sizes_weights__cell_assignment_is_continuous_at_integers` — sweeps the row coordinate across every interior integer boundary and asserts the interpolant has no jumps. Fails previously with a jump of **5.999** (a two-row flip).

`rectangular_uniform.py` passes both as-is.

## Behaviour change

Reconstructions using an adaptive rectangular mesh shift, and **the sign is not consistent** — measured on `autolens_workspace_test` at unfitted model points: `imaging/jax_likelihood/rectangular.py` moves `-651692.998 → -650470.379` (+1223) while `rectangular_rtu.py` moves `-644121.022 → -652043.028` (−7922). That is expected and not a correctness signal, for the reason given in the census section above; the interpolation-accuracy numbers are the metric that discriminates, and they improve in every case.

Downstream `assert_allclose` constants in `autolens_workspace_test` need regenerating (all affected scripts confirmed **passing** on the pre-fix build, so these shifts are attributable to this PR alone). `autogalaxy_workspace_test` needs no changes — it asserts jax-vs-numpy parity, and both backends shift together. **Merge this first**; the workspace PR follows behind the library-first gate.

## Separate observation (not fixed here)

`KERNEL_CDF_DEFAULT_KNOTS = 64` is independent of `mesh_pixels`, so the knot-table inverse used to place mesh nodes drifts from the exact forward transform as the mesh refines: max `|g_roundtrip - ix|` measured at 0.0055 (n=16), 0.0238 (n=32), 0.101 (n=64) index units. Harmless at production mesh sizes (well under 64), but worth scaling `n_knots` with `mesh_pixels` at some point. Out of scope for this PR.

## Validation

- `pytest test_autoarray/` — **1222 passed** on Python **3.12 and 3.13**
- `autolens_workspace_test/scripts/interferometer/jax_grad/gradient.py` — green on **both** legs, all four variants, all FD/AD checks, all gradients live. Eager/jit gap **exactly 0.0** with `assert_eager_jit_consistent` left untouched at `rtol=1e-10`. 3.13: 83s, 3.12: 86s against the 300s cap.
- Stack built from source at the versions of retime run 32741386752 (`jax`/`jaxlib` 0.11.1, `jaxnnls` 1.0.1, `numpy` 2.5.2, `scipy` 1.17.1).

Note `AGENTS.md`: unit tests are NumPy-only, so the workspace parity scripts above are the real gate for the `xp` path.

Refs PyAutoLabs/autolens_workspace_test#279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016azuS2UbS3mFvfxkDFGsKj