### PR TITLE
docs: correct the config-fallback comments on the NNLS warm-start settings (#506)

### DIFF
--- a/autoarray/settings.py
+++ b/autoarray/settings.py
@@ -239,9 +239,11 @@ class Settings:
             try:
                 return conf.instance["general"]["inversion"]["nnls_warm_start_memo"]
             except KeyError:
-                # Workspaces ship their own general.yaml that shadows autoarray's
-                # and will not carry this key, so in practice this fallback *is*
-                # the production default: on, matching the packaged value.
+                # A workspace `general.yaml` normally omits this key, so autoconf's
+                # config-path list falls through to autoarray's packaged value (`true`).
+                # This fallback fires only when the workspace config is the sole config
+                # path (isolated test configs push one dir) and returns that same value,
+                # so both routes resolve identically.
                 return True
 
         return self._nnls_warm_start_memo
@@ -261,9 +263,11 @@ class Settings:
                     "nnls_warm_start_error_tolerance"
                 ]
             except KeyError:
-                # Workspaces ship their own general.yaml that shadows autoarray's
-                # and will not carry this key, so in practice this fallback *is*
-                # the production default, matching the packaged value.
+                # A workspace `general.yaml` normally omits this key, so autoconf's
+                # config-path list falls through to autoarray's packaged value (`1.5`).
+                # This fallback fires only when the workspace config is the sole config
+                # path (isolated test configs push one dir) and returns that same value,
+                # so both routes resolve identically.
                 return 1.5
 
         return self._nnls_warm_start_error_tolerance


### PR DESCRIPTION
## Summary

Comment-only reword of the config-fallback explanation on the two NNLS warm-start settings,
`nnls_warm_start_memo` and `nnls_warm_start_error_tolerance`.

The `except KeyError` comments claimed that a workspace `general.yaml` "shadows" autoarray's, so
the hard-coded fallback "*is* the production default". That overstates what happens. A workspace
`general.yaml` normally omits these keys, and `autonerves`/autoconf's config-path list simply falls
through to autoarray's packaged `general.yaml` — measured from `autolens_workspace`, the resolved
values are `True` and `1.5`, read from the packaged config, never from the fallback. The `KeyError`
branch fires only when the workspace config is the sole config path (isolated test configs push a
single directory), and it returns the same packaged default, so both routes resolve identically.

The reworded comments say exactly that. No behaviour, code or test changes; the `__init__` docstring
entries for both parameters already stated the accurate "`None` (default) reads the packaged value"
and were left untouched.

## API Changes

None — internal changes only.

## Test Plan

```
python -m pytest test_autoarray/inversion/inversion/test_settings_dict.py test_autoarray/util/test_jax_nnls.py -q
# 18 passed
```

Additionally verified empirically from `autolens_workspace` that the workspace `general.yaml` carries
neither key and that `conf.instance["general"]["inversion"][...]` resolves to `True` / `1.5` from
autoarray's packaged config.

Closes nothing; part of PyAutoLabs/autolens_workspace#506.

Generated by the PyAutoLabs agent workflow.
