### PR TITLE
feat: make the colormap config lever loud and documented (#509)

### DIFF
--- a/autoarray/config/visualize/README.md
+++ b/autoarray/config/visualize/README.md
@@ -8,3 +8,52 @@ The `config` folder contains configuration files which customize default **PyAut
 - `mat_wrap.yaml`: Specify the default matplotlib settings when figures and subplots are plotted.
 - `mat_wrap_1d.yaml`: Specify the default matplotlib settings when 1D figures and subplots are plotted.
 - `mat_wrap_2d.yaml`: Specify the default matplotlib settings when 2D figures and subplots are plotted.
+
+# Changing the colormap
+
+Every 2D figure — imaging data, fits, residual maps, inversion reconstructions —
+draws with the colormap named by the `colormap` key of `general.yaml`:
+
+```yaml
+colormap: autoarray   # any matplotlib colormap name, e.g. magma, viridis, inferno
+```
+
+`autoarray` is the colormap bundled with **PyAutoArray**; any other value is
+looked up in matplotlib, so `magma`, `viridis`, `inferno`, `plasma`, `jet` and
+the rest of `list(matplotlib.colormaps)` all work. Editing this one key is
+enough — no plotting code needs changing.
+
+A name matplotlib does not recognise (a typo, say) raises a `ValueError` naming
+the key and the offending value. It is **not** silently swapped back for the
+default, so a colormap setting never goes quietly ignored.
+
+## One figure at a time
+
+To override the colormap for a single figure without touching config, pass
+`colormap=` to any plot function:
+
+```python
+import autoarray.plot as aplt
+
+aplt.plot_array(array=image, colormap="magma")
+aplt.plot_inversion_reconstruction(pixel_values=values, mapper=mapper, colormap="viridis")
+```
+
+The same argument exists on the **PyAutoGalaxy** and **PyAutoLens** plot
+functions (`subplot_fit`, `plot_tracer`, `subplot_sensitivity`, …), which pass
+it straight through to **PyAutoArray**. Its "use the config value" default is
+spelled `None` in **PyAutoArray** and **PyAutoLens**, and `"default"` in
+**PyAutoGalaxy**; both mean the same thing.
+
+## Figures that deliberately ignore the setting
+
+A few figures fix their colormap because the colormap carries meaning that a
+user preference should not override:
+
+- The `array_overlay` of `plot_array` uses `Greys`, so the overlaid array stays
+  legible on top of whatever colormap the main array is drawn in.
+- The weak-lensing figures in **PyAutoLens** use `twilight` for position angles
+  (cyclic data needs a cyclic colormap) and `RdBu_r` for residuals (diverging
+  data needs a diverging colormap centred on zero).
+- The cluster figures in **PyAutoLens** use `gnuplot2`, and the interactive GUI
+  tools use `jet`, to keep faint features visible while masks are drawn by hand.

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -901,34 +901,133 @@ def hide_unused_axes(axes) -> None:
             ax.axis("off")
 
 
+#: Config key holding the default colormap, quoted in error messages.
+_COLORMAP_CONF_KEY = "visualize/general.yaml -> colormap"
+
+
 def _default_colormap() -> str:
-    """Return the colormap name from config, registering the custom one if needed."""
+    """Return the default colormap name for 2D figures.
+
+    The name is read from the ``colormap`` key of ``visualize/general.yaml``.
+    The two failure modes are deliberately kept apart:
+
+    - **No config at all** (``autonerves`` not installed, or no ``colormap``
+      key on the config path — e.g. a bare install with no workspace) falls
+      back quietly to the bundled ``"autoarray"`` colormap.  Nothing is
+      misconfigured, so nothing is said.
+    - **A config value that matplotlib does not recognise** raises
+      ``ValueError``.  A typo'd colormap name used to revert silently to
+      ``"autoarray"``, so the user never learned their setting was ignored.
+
+    Returns
+    -------
+    str
+        A colormap name matplotlib can resolve — either ``"autoarray"`` (the
+        bundled colormap, registered here on first use) or a matplotlib name.
+
+    Raises
+    ------
+    ValueError
+        If the ``colormap`` config key is set to something that is not a
+        registered matplotlib colormap.
+    """
     try:
         from autonerves import conf
-        name = conf.instance["visualize"]["general"]["colormap"]
-    except Exception:
+        from autonerves.exc import ConfigException
+    except ImportError:
         name = "autoarray"
+    else:
+        try:
+            name = conf.instance["visualize"]["general"]["colormap"]
+        except (KeyError, ConfigException):
+            name = "autoarray"
+
     if name == "autoarray":
         from autoarray.plot.segmentdata import register
+
         register()
+        return name
+
+    _validate_colormap(name)
+
     return name
 
 
+def _validate_colormap(name) -> None:
+    """Raise ``ValueError`` unless *name* is a colormap matplotlib knows about.
+
+    Parameters
+    ----------
+    name
+        The colormap name read from config (or passed by the user).
+
+    Raises
+    ------
+    ValueError
+        If *name* is not a string, or is not a registered matplotlib colormap.
+    """
+    import matplotlib
+
+    if isinstance(name, str) and name in matplotlib.colormaps:
+        return
+
+    raise ValueError(
+        f"Unknown colormap {name!r}.\n\n"
+        f"The config key `{_COLORMAP_CONF_KEY}` is set to {name!r}, which is "
+        f"not a colormap matplotlib recognises, so no figure can be drawn "
+        f"with it.\n\n"
+        f"Use either `autoarray` (the colormap bundled with PyAutoArray) or "
+        f"any matplotlib colormap name, for example `magma`, `viridis`, "
+        f"`inferno`, `plasma` or `jet`.\n"
+        f"The full list is `list(matplotlib.colormaps)`."
+    )
+
+
 def _conf_imshow_origin() -> str:
-    """Return the imshow origin from config (``"upper"`` or ``"lower"``)."""
+    """Return the imshow origin from config (``"upper"`` or ``"lower"``).
+
+    An absent config falls back quietly to ``"upper"``; a value matplotlib's
+    ``imshow`` would reject raises ``ValueError`` rather than being silently
+    swapped for the default (same contract as :func:`_default_colormap`).
+    """
     try:
         from autonerves import conf
-        return conf.instance["visualize"]["general"]["general"]["imshow_origin"]
-    except Exception:
+        from autonerves.exc import ConfigException
+    except ImportError:
         return "upper"
+
+    try:
+        origin = conf.instance["visualize"]["general"]["general"]["imshow_origin"]
+    except (KeyError, ConfigException):
+        return "upper"
+
+    if origin not in ("upper", "lower"):
+        raise ValueError(
+            f"Invalid imshow origin {origin!r}.\n\n"
+            f"The config key `visualize/general.yaml -> general -> "
+            f"imshow_origin` must be either `upper` or `lower`."
+        )
+
+    return origin
 
 
 def _conf_output_format() -> str:
-    """Return the default output_format from config (``"show"``, ``"png"``, etc.)."""
+    """Return the default output_format from config (``"show"``, ``"png"``, etc.).
+
+    An absent config falls back quietly to ``"show"``.  The value itself is not
+    validated here — an unsupported format surfaces as matplotlib's own
+    ``savefig`` error, which already names the offending format and lists the
+    supported ones.
+    """
     try:
         from autonerves import conf
+        from autonerves.exc import ConfigException
+    except ImportError:
+        return "show"
+
+    try:
         return conf.instance["visualize"]["general"]["general"]["output_format"]
-    except Exception:
+    except (KeyError, ConfigException):
         return "show"
 
 

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -255,3 +255,219 @@ class TestBothCallSitesHonourTheConfiguredFloor:
 
         assert len(recorded) == 1
         assert recorded[0].vmin == pytest.approx(self.FLOOR)
+
+
+class TestDefaultColormap:
+    """The `visualize/general.yaml -> colormap` lever and its failure modes."""
+
+    @staticmethod
+    def _general():
+        return conf.instance["visualize"]["general"]
+
+    def test__config_value_is_returned(self):
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = "magma"
+
+            assert plot_utils._default_colormap() == "magma"
+        finally:
+            general["colormap"] = original
+
+    def test__absent_key_falls_back_quietly_to_autoarray(self):
+        import matplotlib
+
+        general = self._general()
+        original = general["colormap"]
+        try:
+            del general["colormap"]
+
+            assert plot_utils._default_colormap() == "autoarray"
+        finally:
+            general["colormap"] = original
+
+        # The fallback also registers the bundled colormap, so it is usable.
+        assert "autoarray" in matplotlib.colormaps
+
+    def test__autoarray_value_registers_the_bundled_colormap(self):
+        import matplotlib
+
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = "autoarray"
+
+            assert plot_utils._default_colormap() == "autoarray"
+        finally:
+            general["colormap"] = original
+
+        assert "autoarray" in matplotlib.colormaps
+
+    def test__unknown_value_raises_instead_of_reverting_silently(self):
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = "magmaa"
+
+            with pytest.raises(ValueError) as exc_info:
+                plot_utils._default_colormap()
+        finally:
+            general["colormap"] = original
+
+        message = str(exc_info.value)
+        assert "magmaa" in message
+        assert "colormap" in message
+
+    def test__non_string_value_raises(self):
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = 3
+
+            with pytest.raises(ValueError):
+                plot_utils._default_colormap()
+        finally:
+            general["colormap"] = original
+
+    def test__plot_array_uses_the_config_colormap(self, plot_path, monkeypatch):
+        """One config edit moves the imaging figure's colormap."""
+        from autoarray.structures.arrays.uniform_2d import Array2D
+
+        recorded = {}
+
+        import matplotlib.pyplot as plt
+
+        original_imshow = plt.Axes.imshow
+
+        def spy(self, *args, **kwargs):
+            recorded.setdefault("cmap", kwargs.get("cmap"))
+            return original_imshow(self, *args, **kwargs)
+
+        monkeypatch.setattr(plt.Axes, "imshow", spy)
+
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = "magma"
+
+            aplt.plot_array(
+                array=Array2D.no_mask(
+                    values=np.ones((7, 7)),
+                    pixel_scales=1.0,
+                ),
+                output_path=plot_path,
+                output_filename="config_colormap",
+                output_format="png",
+            )
+        finally:
+            general["colormap"] = original
+
+        assert recorded["cmap"] == "magma"
+
+    def test__per_figure_colormap_overrides_the_config(self, plot_path, monkeypatch):
+        """`colormap=` on a plot function beats the config for that figure only."""
+        from autoarray.structures.arrays.uniform_2d import Array2D
+
+        recorded = {}
+
+        import matplotlib.pyplot as plt
+
+        original_imshow = plt.Axes.imshow
+
+        def spy(self, *args, **kwargs):
+            recorded.setdefault("cmap", kwargs.get("cmap"))
+            return original_imshow(self, *args, **kwargs)
+
+        monkeypatch.setattr(plt.Axes, "imshow", spy)
+
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = "magma"
+
+            aplt.plot_array(
+                array=Array2D.no_mask(
+                    values=np.ones((7, 7)),
+                    pixel_scales=1.0,
+                ),
+                colormap="viridis",
+                output_path=plot_path,
+                output_filename="override_colormap",
+                output_format="png",
+            )
+        finally:
+            general["colormap"] = original
+
+        assert recorded["cmap"] == "viridis"
+
+    def test__inversion_reconstruction_uses_the_config_colormap(
+        self, rectangular_mapper_7x7_3x3, plot_path, monkeypatch
+    ):
+        """The same config edit moves the inversion reconstruction figure."""
+        recorded = {}
+
+        import matplotlib.pyplot as plt
+
+        original_imshow = plt.Axes.imshow
+
+        def spy(self, *args, **kwargs):
+            recorded.setdefault("cmap", kwargs.get("cmap"))
+            return original_imshow(self, *args, **kwargs)
+
+        monkeypatch.setattr(plt.Axes, "imshow", spy)
+
+        general = self._general()
+        original = general["colormap"]
+        try:
+            general["colormap"] = "magma"
+
+            aplt.plot_inversion_reconstruction(
+                pixel_values=np.ones(9),
+                mapper=rectangular_mapper_7x7_3x3,
+                output_path=plot_path,
+                output_filename="inversion_config_colormap",
+                output_format="png",
+            )
+        finally:
+            general["colormap"] = original
+
+        assert recorded["cmap"] == "magma"
+
+
+class TestConfImshowOrigin:
+    @staticmethod
+    def _general():
+        return conf.instance["visualize"]["general"]["general"]
+
+    def test__config_value_is_returned(self):
+        general = self._general()
+        original = general["imshow_origin"]
+        try:
+            general["imshow_origin"] = "lower"
+
+            assert plot_utils._conf_imshow_origin() == "lower"
+        finally:
+            general["imshow_origin"] = original
+
+    def test__absent_key_falls_back_quietly(self):
+        general = self._general()
+        original = general["imshow_origin"]
+        try:
+            del general["imshow_origin"]
+
+            assert plot_utils._conf_imshow_origin() == "upper"
+        finally:
+            general["imshow_origin"] = original
+
+    def test__invalid_value_raises(self):
+        general = self._general()
+        original = general["imshow_origin"]
+        try:
+            general["imshow_origin"] = "sideways"
+
+            with pytest.raises(ValueError) as exc_info:
+                plot_utils._conf_imshow_origin()
+        finally:
+            general["imshow_origin"] = original
+
+        assert "sideways" in str(exc_info.value)


### PR DESCRIPTION
## Summary

The colormap lever (`visualize/general.yaml -> colormap`) already reached every 2D figure, but it was invisible and it failed quietly: `_default_colormap()` wrapped the config read in a bare `except Exception`, so a typo'd colormap name reverted to the bundled `autoarray` map with nothing said. This PR audits the lever end-to-end, makes malformed values loud, and documents both override routes.

- **Loud on malformed, quiet on absent.** `_default_colormap()` now separates the two cases. No `autonerves`, or no `colormap` key on the config path (a bare install with no workspace) → quiet fallback to `autoarray`, as before. A value matplotlib cannot resolve → `ValueError` naming the key, the value, and the fix. The bare `except Exception` is replaced by `ImportError` / `(KeyError, ConfigException)`.
- **Siblings tightened.** `_conf_imshow_origin()` and `_conf_output_format()` get the same narrow excepts. `imshow_origin` additionally rejects anything but `upper`/`lower`; `output_format` is left to matplotlib's own `savefig` error, which already names the format and lists the supported ones.
- **Documented.** `autoarray/config/visualize/README.md` gains a "Changing the colormap" section covering the global config key, the per-figure `colormap=` argument, and the figures that deliberately ignore both.

### Reach audit (deliverable 1 of the issue)

Every 2D raster call in PyAutoArray resolves its colormap from the config, because all three drawing modules default `colormap=None` and then call `_default_colormap()`:

| Module | Line | Raster call |
|--------|------|-------------|
| `autoarray/plot/array.py` | 140-142 → 180, 187 | `imshow` |
| `autoarray/plot/grid.py` | 105-107 → 118-124 | `scatter` |
| `autoarray/plot/inversion.py` | 79-81 → 198, 214, 269 | `imshow` / `pcolormesh` / `tripcolor` |

Everything above them — `autoarray/dataset/plot/`, `autoarray/fit/plot/`, `autoarray/inversion/plot/`, PyAutoGalaxy's `_resolve_colormap("default")` (`autogalaxy/util/plot_utils.py:97-102`), PyAutoLens's `tracer_plots.py` / `sensitivity_plots.py` / `imaging/plot/fit_imaging_plots.py` — either threads `colormap` through or leaves it `None`, so the config value reaches the raster call on every path. **No surface silently ignores the key.**

Callers that omit `colormap=` (e.g. `dataset/plot/imaging_plots.py:186-188`) still honour the config — they just cannot be overridden per-figure from that level. `plot_yx` is a 1D line plot and takes no colormap.

**Deliberate exceptions, now documented in the README rather than left silent:**

- `autoarray/plot/array.py:208` — `cmap="Greys"` for the `array_overlay`. The overlay is drawn *on top of* the main array, so it must contrast with whatever colormap the main array uses.
- `autolens/weak/plot/weak_dataset_plots.py` — `viridis` (ellipticities), `twilight` (position angles: cyclic data needs a cyclic map), `magma` (noise map).
- `autolens/weak/plot/fit_weak_plots.py:119` — `RdBu_r` (diverging, centred on the median residual).
- `autolens/weak/plot/convergence_plots.py:202` — `magma`.
- `autolens/cluster/plot/cluster_plots.py:49` — `CLUSTER_CMAP = "gnuplot2"`.
- `autolens/potential_correction/*`, `autogalaxy/gui/clicker.py` — `jet` in research and interactive-GUI-only code paths.

None of these are changed: the colormap carries meaning (cyclic, diverging, contrast) that a global preference should not silently override.

### Per-figure override (deliverable 2)

The route already exists and is now documented and covered by a test: `colormap=` on any plot function.

```python
aplt.plot_array(array=image, colormap="magma")
aplt.plot_inversion_reconstruction(pixel_values=values, mapper=mapper, colormap="viridis")
```

The "use the config value" default is spelled `None` in PyAutoArray and PyAutoLens, `"default"` in PyAutoGalaxy. No new code was needed.

## API Changes

None — internal changes only. `_default_colormap`, `_conf_imshow_origin` and `_conf_output_format` are private; the `colormap` config key and every public `colormap=` argument keep their names and defaults.

One **behaviour** change is user-visible: a `colormap` (or `imshow_origin`) config value that was previously ignored now raises `ValueError` at plot time instead of silently reverting. Any config that was actually working is unaffected.

## Test Plan

- [x] `python -m pytest test_autoarray/plot -q` — plot suite green
- [x] `python -m pytest test_autoarray -q -n auto` — full suite green
- [x] 11 new tests in `test_autoarray/plot/test_utils.py`: config value returned, absent key → quiet `autoarray` fallback + registration, unknown name → `ValueError`, non-string → `ValueError`, per-figure `colormap=` beats config, and one config edit moves both `plot_array` and `plot_inversion_reconstruction`
- [x] Control-tested: the three cmap-spy assertions were flipped to a sentinel and confirmed to fail, so they really observe the cmap handed to `imshow`
- [x] Acceptance demo rendered an imaging `Array2D` figure and a rectangular-mapper inversion reconstruction under `colormap: magma` — both visually magma, from the one config edit — and a malformed value raised the new error

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `visualize/general.yaml -> colormap` — a value that is not `autoarray` and not a registered matplotlib colormap now raises `ValueError` at plot time instead of silently falling back to `autoarray`.
- `visualize/general.yaml -> general -> imshow_origin` — a value other than `upper` / `lower` now raises `ValueError` instead of silently falling back to `upper`.

### Added
- `autoarray.plot.utils._validate_colormap(name)` (private) — raises `ValueError` unless *name* is a registered matplotlib colormap.

### Migration
- None. Any config that produced the intended figure before produces the same figure now.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXGHBFryzQZMFvAskHe9sQ
