### PR TITLE
perf: rotation-matrix grid transform + one Grid2D per VectorYX2D (numpy deflections phase 3)

### DIFF
--- a/autoarray/geometry/geometry_util.py
+++ b/autoarray/geometry/geometry_util.py
@@ -519,15 +519,20 @@ def transform_grid_2d_to_reference_frame(
 
     shifted_grid_2d = grid_2d - xp.array(centre)
 
-    radius = xp.sqrt(xp.sum(xp.square(shifted_grid_2d), axis=1))
-    theta_coordinate_to_profile = xp.arctan2(
-        shifted_grid_2d[:, 0], shifted_grid_2d[:, 1]
-    ) - xp.radians(angle)
+    # A clockwise rotation by `angle` is the rotation matrix applied to the shifted (y, x)
+    # coordinates, built from one scalar cos / sin of the angle. This is algebraically
+    # identical to the polar form (r, theta - angle) -> (r sin, r cos) but costs two
+    # multiply-adds per coordinate instead of a per-pixel sqrt, arctan2, sin and cos.
+    cos_angle = xp.cos(xp.radians(angle))
+    sin_angle = xp.sin(xp.radians(angle))
+
+    y = shifted_grid_2d[:, 0]
+    x = shifted_grid_2d[:, 1]
 
     return xp.vstack(
         [
-            radius * xp.sin(theta_coordinate_to_profile),
-            radius * xp.cos(theta_coordinate_to_profile),
+            y * cos_angle - x * sin_angle,
+            x * cos_angle + y * sin_angle,
         ]
     ).T
 

--- a/autoarray/structures/vectors/uniform.py
+++ b/autoarray/structures/vectors/uniform.py
@@ -140,11 +140,19 @@ class VectorYX2D(AbstractVectorYX2D):
             grid_2d=values, mask_2d=mask, store_native=store_native
         )
 
-        grid = grid_2d_util.convert_grid_2d(
-            grid_2d=grid, mask_2d=mask, store_native=store_native
-        )
+        # A `Grid2D` already paired with this mask is the grid the vectors are located on: the
+        # `@to_vector_yx` decorator hands the input grid straight through, so re-converting its
+        # values and rebuilding a second `Grid2D` on every profile evaluation would only pay the
+        # constructor twice for the same object.
+        if isinstance(grid, Grid2D) and grid.mask is mask and not store_native:
+            self.grid = grid
+        else:
+            grid = grid_2d_util.convert_grid_2d(
+                grid_2d=grid, mask_2d=mask, store_native=store_native
+            )
 
-        self.grid = Grid2D(values=grid, mask=mask)
+            self.grid = Grid2D(values=grid, mask=mask)
+
         self.mask = mask
 
         super().__init__(values)


### PR DESCRIPTION
## Summary
Phase 3 of the `numpy-deflections-cpu` epic (PyAutoGalaxy#598) — the shared-geometry lever every `@transform`-decorated profile pays once per call.

- `geometry_util.transform_grid_2d_to_reference_frame` builds the clockwise rotation from one scalar `cos`/`sin` of the angle and applies it as two multiply-adds per coordinate (`[y cos a − x sin a, x cos a + y sin a]`), instead of the polar form's per-pixel `sqrt` + `arctan2` + `sin` + `cos`. Algebraically identical (max abs difference 2e-15 on a 15k-point grid); 1.42 ms → 0.21 ms on that grid (~7×).
- `VectorYX2D` reuses the `Grid2D` it is handed when it is already paired with the same mask. `@to_vector_yx` passes the input grid straight through, and the constructor was re-converting its values and rebuilding a second `Grid2D` on every deflection evaluation. One `Grid2D` construction per call instead of two; other inputs take the unchanged conversion path.

Net on this box (`OMP_NUM_THREADS=1`, hst 15,361-point `Grid2D`): `Isothermal.deflections_yx_2d_from` 1.95 ms → 0.93 ms with the PyAutoGalaxy hoists from #598 on top. The measurement of record (before/after on hst + euclid for all nine profiles, pins at rtol 1e-6) lands in the autolens_profiling PR of this phase.

The rotation is exact where the polar form left round-off: an on-axis point at angle 0 now gives an x-component of exactly `0.0` where it was `~5e-17`. That is what moved one pinned sample in the autolens_profiling `stellar` cell (relative shift 1.0 on a 1e-17 value) and is re-pinned there with provenance; every other pin held.

Merge order: this PR → PyAutoGalaxy#599 (profiles) → autolens_profiling (numbers).

## API Changes
No public API change. `transform_grid_2d_to_reference_frame` returns the same coordinates; `VectorYX2D(values, grid, mask)` accepts the same inputs and, when `grid` is a `Grid2D` on `mask`, its `.grid` is now that object rather than a copy.
See full details below.

## Test Plan
- [x] `test_autoarray` — 1349 passed, 61 skipped (`-n 4`); geometry, grids, vectors and decorator tests re-run after each change
- [x] `ruff check` / `ruff format --check` — no new findings in the changed files (both were already format-clean on `main`)
- [x] Field-level A/B vs `main` on the hst grid for Isothermal / PowerLaw / NFW / NFWSph / gNFW: max relative difference ≤ 1e-8
- [x] autolens_profiling `scripts/lens/deflections/{total,dark,stellar}.py` hst + euclid: every pin held at rtol 1e-6 except the exact-zero sample above

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- none

### Changed
- `autoarray.util.geometry.transform_grid_2d_to_reference_frame(grid_2d, centre, angle, xp)` — same signature and result; rotation-matrix evaluation (no per-pixel `arctan2`/`sin`/`cos`).
- `autoarray.VectorYX2D.__init__(values, grid, mask, store_native=False)` — when `grid` is a `Grid2D` whose `.mask is mask` and `store_native` is False, `self.grid` is `grid` itself instead of a re-converted copy.

### Migration
- none required

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Re4JLhTCFnGYeez8oEyM6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Re4JLhTCFnGYeez8oEyM6M)_