### PR TITLE
feat: per-call arcsec_after_decimal override for arcsecond tick labels

### DIFF
--- a/autoarray/plot/array.py
+++ b/autoarray/plot/array.py
@@ -61,6 +61,7 @@ def plot_array(
     cb_unit: Optional[str] = None,
     line_colors: Optional[List] = None,
     origin_imshow: Optional[str] = None,
+    arcsec_after_decimal: Optional[bool] = None,
     # --- figure control (used only when ax is None) -----------------------------
     figsize: Optional[Tuple[int, int]] = None,
     output_path: Optional[str] = None,
@@ -126,6 +127,11 @@ def plot_array(
         When ``True`` a ``LogNorm`` is applied.
     origin_imshow
         Passed directly to ``imshow`` (``"upper"`` or ``"lower"``).
+    arcsec_after_decimal
+        Per-call override of the ``ticks.symbol_over_decimal`` config flag.
+        When ``True`` the arcsecond tick labels place the ``″`` symbol over the
+        decimal point (``3.″8``) instead of suffixing it (``3.8"``); when ``False``
+        the suffix form is forced.  ``None`` (the default) reads the config.
     figsize
         Figure size in inches.
     output_path
@@ -320,7 +326,7 @@ def plot_array(
     )
 
     if extent is not None:
-        apply_extent(ax, extent)
+        apply_extent(ax, extent, symbol_over_decimal=arcsec_after_decimal)
 
     # --- output ----------------------------------------------------------------
     if owns_figure:

--- a/autoarray/plot/grid.py
+++ b/autoarray/plot/grid.py
@@ -37,6 +37,7 @@ def plot_grid(
     buffer: float = 0.1,
     extent: Optional[Tuple[float, float, float, float]] = None,
     force_symmetric_extent: bool = True,
+    arcsec_after_decimal: Optional[bool] = None,
     # --- figure control (used only when ax is None) -----------------------------
     figsize: Optional[Tuple[int, int]] = None,
     output_path: Optional[str] = None,
@@ -77,6 +78,11 @@ def plot_grid(
     force_symmetric_extent
         When ``True`` (and *extent* is auto-computed) the limits are made
         symmetric about the origin so the plot is centred.
+    arcsec_after_decimal
+        Per-call override of the ``ticks.symbol_over_decimal`` config flag.
+        When ``True`` the arcsecond tick labels place the ``″`` symbol over the
+        decimal point (``3.″8``) instead of suffixing it (``3.8"``); when ``False``
+        the suffix form is forced.  ``None`` (the default) reads the config.
     figsize
         Figure size in inches ``(width, height)``.
     output_path
@@ -178,7 +184,7 @@ def plot_grid(
         y_abs = max(abs(extent[2]), abs(extent[3]))
         extent = [-x_abs, x_abs, -y_abs, y_abs]
 
-    apply_extent(ax, extent)
+    apply_extent(ax, extent, symbol_over_decimal=arcsec_after_decimal)
 
     # --- output ----------------------------------------------------------------
     if owns_figure:

--- a/autoarray/plot/inversion.py
+++ b/autoarray/plot/inversion.py
@@ -34,6 +34,7 @@ def plot_inversion_reconstruction(
     use_log10: bool = False,
     zoom_to_brightest: bool = True,
     zoom_extent_scale: float = 1.0,
+    arcsec_after_decimal: Optional[bool] = None,
     # --- overlays ---------------------------------------------------------------
     lines: Optional[List[np.ndarray]] = None,
     line_colors: Optional[List] = None,
@@ -73,6 +74,11 @@ def plot_inversion_reconstruction(
         Apply ``LogNorm``.
     zoom_to_brightest
         Pass through to ``mapper.extent_from``.
+    arcsec_after_decimal
+        Per-call override of the ``ticks.symbol_over_decimal`` config flag.
+        When ``True`` the arcsecond tick labels place the ``″`` symbol over the
+        decimal point (``3.″8``) instead of suffixing it (``3.8"``); when ``False``
+        the suffix form is forced.  ``None`` (the default) reads the config.
     lines
         Line overlays (e.g. critical curves).
     grid
@@ -163,7 +169,7 @@ def plot_inversion_reconstruction(
     if grid is not None:
         ax.scatter(grid[:, 1], grid[:, 0], s=1, c="w", alpha=0.5)
 
-    apply_extent(ax, extent)
+    apply_extent(ax, extent, symbol_over_decimal=arcsec_after_decimal)
 
     apply_labels(
         ax,

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -1106,7 +1106,7 @@ def _round_ticks(values: np.ndarray, sig: int = 2) -> np.ndarray:
     return rounded
 
 
-def _arcsec_labels(ticks) -> List[str]:
+def _arcsec_labels(ticks, symbol_over_decimal: Optional[bool] = None) -> List[str]:
     """Format tick values as arcsecond coordinate strings.
 
     Whole-number tick sets render without a decimal point, so
@@ -1117,6 +1117,16 @@ def _arcsec_labels(ticks) -> List[str]:
     decimal labels keep the suffix form ``3.8"``.  When
     ``ticks.symbol_over_decimal`` is true, labels use the double-prime arcsecond
     symbol and decimal labels place it over the decimal point, e.g. ``3.″8``.
+
+    Parameters
+    ----------
+    ticks
+        The tick values to label.
+    symbol_over_decimal
+        Per-call override of the ``ticks.symbol_over_decimal`` config flag.
+        ``True`` forces the symbol-over-decimal form and ``False`` forces the
+        suffix form, whatever the config says.  ``None`` (the default) reads
+        the config, so callers that do not pass it behave exactly as before.
     """
     minus_in_math = _conf_ticks_flag("minus_in_math", False)
 
@@ -1132,7 +1142,9 @@ def _arcsec_labels(ticks) -> List[str]:
             label if "." in label else f"{float(v):.1f}"
             for label, v in zip(labels, ticks)
         ]
-    if _conf_ticks_flag("symbol_over_decimal", False):
+    if symbol_over_decimal is None:
+        symbol_over_decimal = _conf_ticks_flag("symbol_over_decimal", False)
+    if symbol_over_decimal:
         symbol_labels = []
         for label in labels:
             if "." in label:
@@ -1147,6 +1159,7 @@ def _arcsec_labels(ticks) -> List[str]:
 def apply_extent(
     ax,
     extent: Tuple[float, float, float, float],
+    symbol_over_decimal: Optional[bool] = None,
 ) -> None:
     """
     Apply axis limits and inward-pulled, rounded, arcsecond-labelled ticks to *ax*.
@@ -1154,6 +1167,10 @@ def apply_extent(
     Tick count and inward factor are read from ``visualize/general.yaml``
     (``ticks.number_of_ticks_2d`` and ``ticks.extent_factor_2d``), defaulting
     to 3 ticks and factor 0.75.
+
+    ``symbol_over_decimal`` is a per-call override of the
+    ``ticks.symbol_over_decimal`` config flag, forwarded to
+    :func:`_arcsec_labels`; ``None`` (the default) reads the config.
     """
     factor = _conf_ticks("extent_factor_2d", 0.75)
     n = int(_conf_ticks("number_of_ticks_2d", 3))
@@ -1166,8 +1183,8 @@ def apply_extent(
     yticks = _round_ticks(_inward_ticks(ymin, ymax, factor, n))
     ax.set_xticks(xticks)
     ax.set_yticks(yticks)
-    ax.set_xticklabels(_arcsec_labels(xticks))
-    ax.set_yticklabels(_arcsec_labels(yticks))
+    ax.set_xticklabels(_arcsec_labels(xticks, symbol_over_decimal=symbol_over_decimal))
+    ax.set_yticklabels(_arcsec_labels(yticks, symbol_over_decimal=symbol_over_decimal))
 
     # The y-tick labels are rotated 90 degrees elsewhere; without an explicit
     # centre alignment a rotated label anchors at its right edge and visually

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -91,6 +91,65 @@ def test_arcsec_labels_minus_in_math():
         ticks["minus_in_math"] = original_minus
 
 
+def test_arcsec_labels_symbol_over_decimal_argument_overrides_config():
+    # The per-call argument alone switches the format on, with the config flag
+    # left at its default (false) and `conf.instance` never mutated.
+    assert _arcsec_labels([-2.1, -0.044, 2.0], symbol_over_decimal=True) == [
+        "-2.″1",
+        "-0.″044",
+        "2.″0",
+    ]
+    assert _arcsec_labels([3.8], symbol_over_decimal=True) == ["3.″8"]
+    assert _arcsec_labels([-1.0, 0.0, 1.0], symbol_over_decimal=True) == [
+        "-1″",
+        "0″",
+        "1″",
+    ]
+
+
+def test_arcsec_labels_symbol_over_decimal_argument_false_beats_config():
+    # The override wins in both directions: an explicit False forces the suffix
+    # form even when the config flag is on.
+    ticks = conf.instance["visualize"]["general"]["ticks"]
+    original = ticks.get("symbol_over_decimal", False)
+    try:
+        ticks["symbol_over_decimal"] = True
+
+        assert _arcsec_labels([-2.1, -0.044, 2.0], symbol_over_decimal=False) == [
+            '-2.1"',
+            '-0.044"',
+            '2.0"',
+        ]
+        assert _arcsec_labels([3.8], symbol_over_decimal=False) == ['3.8"']
+    finally:
+        ticks["symbol_over_decimal"] = original
+
+
+def test_arcsec_labels_symbol_over_decimal_none_reads_config():
+    # None (the default) leaves the config in charge, so every existing caller
+    # is unchanged.
+    ticks = conf.instance["visualize"]["general"]["ticks"]
+    original = ticks.get("symbol_over_decimal", False)
+    try:
+        ticks["symbol_over_decimal"] = True
+
+        assert _arcsec_labels([-2.1, -0.044, 2.0], symbol_over_decimal=None) == [
+            "-2.″1",
+            "-0.″044",
+            "2.″0",
+        ]
+
+        ticks["symbol_over_decimal"] = False
+
+        assert _arcsec_labels([-2.1, -0.044, 2.0], symbol_over_decimal=None) == [
+            '-2.1"',
+            '-0.044"',
+            '2.0"',
+        ]
+    finally:
+        ticks["symbol_over_decimal"] = original
+
+
 class TestNormFrom:
     """The one colour-norm helper `plot_array`, `plot_inversion_reconstruction`
     and `autogalaxy.util.plot_utils.norm_from` all build their norms with.


### PR DESCRIPTION
Closes #546.

## Summary

The arcsecond symbol-over-decimal *formatting* already shipped: `_arcsec_labels` renders `3.″8` when `ticks.symbol_over_decimal` is set in `visualize/general.yaml`. But the switch was **global config only**, so a script wanting it for one figure had to mutate `conf.instance` and restore it afterwards — the fragile, stateful pattern the originating request was filed to remove.

This threads a per-call override down the plotting stack, so `plot_array(..., arcsec_after_decimal=True)` works on a single call without touching config.

The public name (`arcsec_after_decimal`, the one users read) differs from the internal/config name (`symbol_over_decimal`, already shipped and documented in `general.yaml`). Renaming the config key would break anyone who has already set it, so the two are bridged at each public function's `apply_extent` call rather than unified.

## API Changes

Three public plotting functions gain one optional keyword, `arcsec_after_decimal: Optional[bool] = None` — `plot_array`, `plot_grid` and `plot_inversion_reconstruction`. `True` forces the symbol-over-decimal form, `False` forces the suffix form, and `None` (the default) reads the config flag exactly as before.

Purely additive. No signature is reordered, no default changes, and `None` is byte-for-byte the old behaviour — the config read simply moved into an `if symbol_over_decimal is None:` fallback. The config key `symbol_over_decimal` is unchanged and `general.yaml` is untouched.

See full details below.

## Test Plan

- [x] `test_autoarray/plot` → **35 passed** (`test_utils.py`: 33 = 30 baseline + 3 new)
- [x] The four pre-existing config-driven arcsec tests pass **unmodified**
- [x] Three new tests cover the override in both directions: argument-only with config off and `conf.instance` never mutated; explicit `False` beating a config `True`; `None` still following config in both states
- [x] End-to-end through the wrapper — `plot_array` at all three flag values on a 10×10 `Array2D`, reading the labels back off the axes:
  - `arcsec_after_decimal=True` → `['-1.″9', '0.″0', '1.″9']`
  - `arcsec_after_decimal=None` → `['-1.9"', '0.0"', '1.9"']`
  - `arcsec_after_decimal=False` → `['-1.9"', '0.0"', '1.9"']`
- [x] Wider suite `test_autoarray` → 1408 passed, 74 skipped, **8 failed — all pre-existing and unrelated**, confirmed by re-running them in a detached worktree at the pristine branch point `35aa681f`, where they fail identically. Cause is `ModuleNotFoundError: No module named 'numba'` in this container; all 8 are w-tilde / sparse-operator tests under `test_autoarray/inversion/`, which this diff does not touch.

> Heart gate: `pyauto-heart` is not reachable from this remote session, so the documented fallback (per-repo pytest as the gate) was used — see the counts above.

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Added
- `autoarray.plot.plot_array(..., arcsec_after_decimal: Optional[bool] = None)` — per-call override of the `ticks.symbol_over_decimal` config flag
- `autoarray.plot.plot_grid(..., arcsec_after_decimal: Optional[bool] = None)` — same
- `autoarray.plot.plot_inversion_reconstruction(..., arcsec_after_decimal: Optional[bool] = None)` — same
- `autoarray.plot.utils.apply_extent(ax, extent, symbol_over_decimal: Optional[bool] = None)` — forwards the override to the label formatter
- `autoarray.plot.utils._arcsec_labels(ticks, symbol_over_decimal: Optional[bool] = None)` — `None` reads config, `True`/`False` override it

### Removed
- Nothing.

### Migration
- None required — every existing call site keeps its current behaviour.
- Before (per-figure override): `conf.instance["visualize"]["general"]["ticks"]["symbol_over_decimal"] = True` … then restore it
- After: `plot_array(array=array, arcsec_after_decimal=True)`

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mofs7R3chP12wzoCPjnaw

---
_Generated by [Claude Code](https://claude.ai/code/session_019mofs7R3chP12wzoCPjnaw)_