### PR TITLE
feat: declare Pixelization.__solved_parameters__ for model figures (PyAutoLens#736)

### DIFF
--- a/autoarray/inversion/pixelization.py
+++ b/autoarray/inversion/pixelization.py
@@ -8,6 +8,13 @@ from autoarray import exc
 
 
 class Pixelization:
+    # The source reconstruction is solved for by the inversion, not sampled by
+    # the non-linear search, so it has no prior and never appears in
+    # `model.info`. PyAutoFit's `graph_spec` reads this class attribute (the
+    # `__solved_parameters__` protocol) to draw `reconstruction` as a `solved`
+    # row in model figures.
+    __solved_parameters__ = ("reconstruction",)
+
     def __init__(
         self,
         mesh: AbstractMesh,


### PR DESCRIPTION
## Summary
PyAutoArray half of model-figures phase 3 (PyAutoLens#736). PyAutoFit's `graph_spec` now reads a class attribute `__solved_parameters__` (PyAutoFit sibling PR) and draws each declared name as a `solved` pill. `Pixelization` declares `("reconstruction",)`: the source reconstruction is solved by the inversion, so the figure no longer shows the pixelization as a component with nothing sampled. One class attribute; no runtime behaviour changes.

## API Changes
Added class attribute `Pixelization.__solved_parameters__ = ("reconstruction",)` (consumed by PyAutoFit's model figures). See full details below.

## Test Plan
- [x] `test_autoarray/inversion` 545 passed (serial, task worktree); black clean.
- [x] Rendered with real classes in PyAutoLens' `test_autolens/model_figure` (19 passed): `reconstruction · solved` on the Pixelization card.
- [ ] CI.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autoarray.inversion.pixelization.Pixelization.__solved_parameters__ = ("reconstruction",)` — protocol attribute read by `autofit.graph_spec`.

### Migration
- None.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178yLU9v19GtACcRPFggjGa
